### PR TITLE
Scipy transforms

### DIFF
--- a/devtools/conda-envs/dev-env.yml
+++ b/devtools/conda-envs/dev-env.yml
@@ -1,0 +1,30 @@
+name: mupt-dev
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+    # Basic Python dependencies
+    - python>=3.12
+    - pip
+    - jupyterlab
+
+    # Unit testing
+    - pytest
+    - pytest-cov
+    - codecov
+
+    # Scientific computing
+    - numpy>=2.0
+    - scipy>=1.16.0 # required to allow use of RigidTransform
+    - networkx
+
+    # Visualization
+    - rich
+    - matplotlib
+    - ipympl
+
+    # Molecular libraries
+    - rdkit
+
+    # - pip:
+        # - foo>=bar

--- a/mupt/chemistry/linkers.py
+++ b/mupt/chemistry/linkers.py
@@ -29,11 +29,11 @@ def get_num_linkers(rdmol : Mol) -> int:
     
 def get_linker_and_bridgehead_idxs(rdmol : Mol) -> Generator[tuple[int, int], None, None]:
     '''Get the linker and bridgehead indices of all ports found in an RDKit Mol'''
-    # DON'T de-duplify indices of substruct matches (fails to catch both ports on a neutronium)
+    # DON'T de-duplify (i.e. uniquify) indices of substruct matches (fails to catch both ports on a neutronium)
     for (linker_id, bh_id) in rdmol.GetSubstructMatches(LINKER_QUERY_MOL, uniquify=False):
         yield linker_id, bh_id # unpacked purely for self-documentation
 
-def renumber_linkers_as_last(rdmol : Mol) -> Mol:
+def renumber_linkers_as_last(rdmol : Mol) -> Mol: # TODO: make optionally in-place
     '''
     Returns a copy of a Mol whose atom indices are renumbered such that:
     * all #L linker atoms are assigned the last L indices (i.e. occur after all real atoms in order)

--- a/mupt/geometry/coordinates/basis.py
+++ b/mupt/geometry/coordinates/basis.py
@@ -7,12 +7,6 @@ import numpy as np
 from ..arraytypes import Shape, N, Dims, Numeric
 
 
-orthogonality_test = np.array([
-    [1, 2, 5],
-    [2, 2, -4],
-    [3, -2, 1],
-]) # an example of a matrix whose columns are mutually orthogonal but whose rows are not
-
 def is_diagonal(matrix : np.ndarray[Shape[N, N], Numeric]) -> bool: # TODO: generalize to work for other diagonals
     '''Determine whether a matrix is digonal, i.e. has no nonzero elements off of the main diagonal'''
     return np.allclose(matrix - np.diag(np.diagonal(matrix)), 0.0)

--- a/mupt/geometry/coordinates/quaternions.py
+++ b/mupt/geometry/coordinates/quaternions.py
@@ -1,4 +1,0 @@
-'''Transformation and conversion operations on Hamiltonian quaterions'''
-
-from scipy.spatial.transform import Rotation
-# import rowan ## TOSELF: worth employing eventually for HOOMD compat?

--- a/mupt/geometry/random_walk.py
+++ b/mupt/geometry/random_walk.py
@@ -73,7 +73,7 @@ def random_walk_jointed_chain(
         if step_direction_prev is None:
             step_direction_prev = step_direction
             
-        # over [-pi, pi], cosine is monotonically decreasing, so overly-large steps will have cosine BELOW the cutoff
+        # over [0, pi], cosine is monotonically decreasing, so overly-large steps will have cosine BELOW the cutoff
         while np.dot(step_direction, step_direction_prev) < c_max: 
             step_direction = random_direction(dimension=dimension) # draw new step within cone of movement by rejection sampling
         

--- a/mupt/geometry/shapes.py
+++ b/mupt/geometry/shapes.py
@@ -3,7 +3,7 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Generic, Optional, Sequence
+from typing import Generic, Optional, Sequence, Union
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -11,12 +11,12 @@ from functools import cached_property
 
 import numpy as np
 from scipy.spatial import ConvexHull, Delaunay
+from scipy.spatial.transform import Rotation, RigidTransform
 
 from .arraytypes import Shape, Numeric, M, N, P, Dims
-from .coordinates.basis import is_columnspace_mutually_orthogonal
-from .transforms.affine import (
-    affine_matrix_from_linear_and_center,
-    apply_affine_transformation_to_points,
+from .coordinates.basis import (
+    is_columnspace_mutually_orthogonal,
+    is_orthogonal,
 )
 
 
@@ -29,7 +29,7 @@ class Plane(Generic[Numeric]):
     a : Numeric
     b : Numeric
     c : Numeric
-    d : Numeric = 0
+    d : Numeric = 0.0
     
     @classmethod
     def from_normal_and_point(cls, normal : np.ndarray[Shape[3], Numeric], point : np.ndarray[Shape[3], Numeric]) -> 'Plane':
@@ -50,6 +50,7 @@ class Plane(Generic[Numeric]):
         '''Test whether a point lies on the plane defined'''
         if len(point) == 1 and isinstance(point[0], (Sequence, np.ndarray)):
             point = point[0] # correct missing star-args for Sequence-like
+            # TODO: convert Sequences to numpy arrays
         
         assert len(point) == 3
         x, y, z = point
@@ -86,7 +87,7 @@ class BoundedShape(ABC, Generic[Numeric]): # template for numeric type (some ite
         ... 
         
     @abstractmethod
-    def affine_transformation(self, affine_matrix : np.ndarray[Shape[N, N], Numeric]) -> 'BoundedShape':
+    def apply_rigid_transformation(self, transform : RigidTransform) -> 'BoundedShape':
         '''Apply a rigid transformation to the body'''
         ...
      
@@ -101,7 +102,7 @@ class PointCloud(BoundedShape[Numeric]):
     '''A cluster of points in 3D space'''
     def __init__(self, positions : np.ndarray[Shape[3], Numeric]=None) -> None:
         if positions is None:
-            positions = np.empty((0, 0))
+            positions = np.empty((0, 3), dtype=float)
         self.positions = positions
         
     def __repr__(self):
@@ -128,12 +129,10 @@ class PointCloud(BoundedShape[Numeric]):
     def contains(self, point : np.ndarray[Shape[3], Numeric]) -> bool:
         return (self.triangulation.find_simplex(point) != -1).astype(object) # need to cast from numpy bool to Python bool
     
-    def affine_transformation(self, affine_matrix : np.ndarray[Shape[4, 4], Numeric]) -> 'PointCloud':
-        return PointCloud(
-            positions=apply_affine_transformation_to_points(self.positions, affine_matrix)
-        )
+    def apply_rigid_transformation(self, transform : RigidTransform) -> 'PointCloud':
+        return PointCloud(positions=transform.apply(self.positions))
     
-# @dataclass
+@dataclass
 class Ellipsoid(BoundedShape[Numeric]):
     '''
     A generalized spherical body, with potentially asymmetric orthogonal principal axes and arbitrary centroid
@@ -141,23 +140,62 @@ class Ellipsoid(BoundedShape[Numeric]):
     Represented by a (not necessarily isotropic) scaling of the basis vectors and a rigid transformation,
     which, together, map the points on a unit sphere at the origin to the surface of the ellipsoid
     '''
-    # initialization
-    def __init__(self, basis : np.ndarray[Shape[4, 4], Numeric]=None) -> None:
-        if basis is None:
-            basis = np.eye(4, dtype=float)
-            
-        assert self.is_valid_ellipsoid_matrix(basis)
-        self.basis = basis
-        
-    def __repr__(self):
-        return f'{self.__class__.__name__}(radii={self.radii}, center={self.centroid})'
-        
-    @cached_property
-    def basis_inverse(self) -> np.ndarray[Shape[4, 4], Numeric]:
-        '''Transformation which maps this ellipsoid to the unit sphere centered at the origin
-        Cached to avoid matrix inverse recalculation'''
-        return np.linalg.inv(self.basis) # precompute inverse for later use
+    radii  : np.ndarray[Shape[3], Numeric] = field(default_factory=lambda: np.ones(3, dtype=float))  # by default, make a unit sphere
+    center : np.ndarray[Shape[3], Numeric] = field(default_factory=lambda: np.zeros(3, dtype=float)) # by default, center at origin
+    orientation : Rotation = field(default_factory=Rotation.identity) # by default, no rotation
     
+    # TODO: check shapes of radii and center post-init
+    
+    def __eq__(self, other : 'Ellipsoid') -> bool:
+        return np.allclose(self.radii, other.radii) \
+            and np.allclose(self.center, other.center) \
+            and np.allclose(self.orientation.as_matrix(), other.orientation.as_matrix())
+
+    # initialization
+    @classmethod
+    def from_components(
+        cls,
+        radius_x : float=1.0,
+        radius_y : float=1.0,
+        radius_z : float=1.0, 
+        center : Optional[np.ndarray[Shape[3], Numeric]]=None,
+        orientation : Optional[Union[Rotation, np.ndarray[Shape[3, 3], Numeric]]]=None
+    ) -> 'Ellipsoid':
+        '''Instantiate an ellipsoid its axis lengths, center, and orientation in a more flexible format'''
+        if center is None:
+            center = np.zeros(3, dtype=float)
+            
+        if orientation is None:
+            orientation = Rotation.identity()
+        elif isinstance(orientation, np.ndarray):
+            assert orientation.shape == (3, 3), 'Orientation must be a 3x3 rotation matrix' # TODO: make thse proper Exceptions
+            assert is_orthogonal(orientation) , 'Orientation must be an orthogonal matrix'  # TODO: make thse proper Exceptions
+            orientation = Rotation.from_matrix(orientation)
+            
+        return cls(
+            radii=np.array([radius_x, radius_y, radius_z], dtype=float),
+            center=center,
+            orientation=orientation,
+        )
+        
+    @classmethod
+    def from_axis_lengths_and_transform(
+        cls,
+        radius_x : float=1.0,
+        radius_y : float=1.0,
+        radius_z : float=1.0, 
+        transform : Optional[RigidTransform]=None,
+    ) -> 'Ellipsoid':
+        '''Instantiate an ellipsoid from its axis lengths and a rigid transformation'''
+        return cls.from_components(
+            radius_x=radius_x,
+            radius_y=radius_y,
+            radius_z=radius_z,
+            center=None if (transform is None) else transform.translation,
+            orientation=None if (transform is None) else transform.rotation,
+        )
+
+    # Matrix presentation of the ellipsoid
     @staticmethod
     def is_valid_ellipsoid_matrix(basis : np.ndarray[Shape[4, 4], Numeric]) -> bool:
         '''Check that an affine matrix could represent an ellipsoid'''
@@ -170,61 +208,65 @@ class Ellipsoid(BoundedShape[Numeric]):
             and np.isclose(w, 1.0), # ensure homogeneous scale of the center is 1 (i.e. unprojected)
         )
         
-    @classmethod
-    def from_axes_and_center(
-        cls,
-        axes : np.ndarray[Shape[3, 3], Numeric],
-        center : Optional[np.ndarray[Shape[3], Numeric]]=None,
-    ) -> 'Ellipsoid':
-        '''Instantiate an ellipsoid from a matrix of its axes and
-        an (optional) location for its center (by default, the origin)'''
-        # NOTE: explicitly using Ellipsoid (rather than cls) to prevent circular call in child classes (i.e. Sphere)
-        return Ellipsoid(basis=affine_matrix_from_linear_and_center(axes, center=center))
-    
-    @classmethod
-    def from_axis_lengths_and_center(
-        cls,
-        radius_x : float=1.0,
-        radius_y : float=1.0,
-        radius_z : float=1.0, 
-        center : Optional[np.ndarray[Shape[3], Numeric]]=None,
-    ) -> 'Ellipsoid':
-        '''Instantiate an ellipsoid its axis lengths andan (optional) location for its center (by default, the origin)'''
-        # TODO: add some "smart" conversion of arrays/diagonal matrices as input
-        return cls.from_axes_and_center(
-            axes=np.diag([radius_x, radius_y, radius_z]),
-            center=center
+    @property
+    def transformation(self) -> RigidTransform:
+        '''The rigid transformation defining this ellipsoids center and orientation'''
+        return RigidTransform.from_components(
+            translation=self.center,
+            rotation=self.orientation,
         )
+
+    def scaling_matrix(self, as_affine : bool=True) -> np.ndarray[Union[Shape[3, 3], Shape[4, 4]], Numeric]:
+        '''The scaling matrix which defines the radii of the ellipsoid'''
+        if as_affine:
+            return np.diag([*self.radii, 1.0])  # add a 1.0 for the homogeneous coordinate
+        return np.diag(self.radii)
+        
+    @property
+    def matrix(self) -> np.ndarray[Shape[4, 4], Numeric]:
+        '''
+        An affine matrix which represents this Ellipsoid
+        
+        Has the effect of transforming the unit sphere at the origin, 
+        (in homogeneous coordinates) to the surface of this Ellipsoid
+        '''
+        return self.transformation.as_matrix() @ self.scaling_matrix(as_affine=True)
+    basis = matrix
+        
+    @property
+    def inverse(self) -> np.ndarray[Shape[4, 4], Numeric]:
+        '''
+        Transformation which maps this ellipsoid to the unit sphere centered at the origin
+        Inverse of Ellipsoid.matrix
+        '''
+        return np.linalg.inv(self.matrix) # precompute inverse for later use
+    inv = inverse
         
     # interfaces
     @property
     def centroid(self) -> np.ndarray[Shape[3], Numeric]:
-        return self.basis[:-1, -1] # return translation vector of center
+        return self.center
     
     @property
     def volume(self) -> Numeric:
-        return 4/3 * np.pi * np.linalg.det(self.basis)
+        return 4/3 * np.pi * np.prod(self.radii) # DEVNOTE: determination of rotation is always 1, so we may as well skip it and the whole determinant calculation
+        # return 4/3 * np.pi * np.linalg.det(self.matrix)
     
     def contains(self, point : np.ndarray[Shape[3], Numeric]) -> bool:   # TODO: decide whether containment should be boundary-inclusive
         return (np.linalg.norm(
-            apply_affine_transformation_to_points(
-                positions=point,
-                transform=self.basis_inverse, # inverse transform maps all points inside the ellipsoid to points within the unit ball
-            ),
-            axis=-1,
+            (self.transformation.inv().apply(point) / self.radii), # reduce containment check to comparison with auxiliary unit sphere
+            axis=1,
         ) < 1).astype(object) # need to cast from numpy bool to Python bool
+
+    def apply_rigid_transformation(self, transformation : RigidTransform) -> 'Ellipsoid':
+        net_transformation = transformation * self.transformation
+        return Ellipsoid(
+            radii=self.radii,
+            center=net_transformation.translation,
+            orientation=net_transformation.rotation,
+        )
     
-    def affine_transformation(self, affine_matrix : np.ndarray[Shape[4, 4], Numeric]) -> 'Ellipsoid':
-        return Ellipsoid(affine_matrix @ self.basis)
-    
-    # visualization
-    @property
-    def radii(self) -> np.ndarray[Shape[3], Numeric]:
-        '''The lengths of the principal axes of the ellipsoid'''
-        return np.linalg.norm(self.basis[:-1, :-1], axis=0)
-        # TODO: rewrite as transpose product, exploiting OD decomposition of valid ellipsoid matrix
-    axes_lengths = radii # alias for convenience
-    
+    # visualization   
     def surface_mesh(self, n_theta : int=100, n_phi : int=100) -> np.ndarray[Shape[M, P, 3], Numeric]:
         '''
         Generate a mesh of points on the surface of the ellipsoid
@@ -257,26 +299,33 @@ class Ellipsoid(BoundedShape[Numeric]):
             0.0:np.pi:n_phi*1j,
         ] # (magnitude of) complex step size is interpreted by numpy as a number of points
 
+        a, b, c = self.radii 
         positions = np.zeros((n_theta, n_phi, 3), dtype=float)
-        positions[..., 0] = r * np.sin(phi) * np.cos(theta)
-        positions[..., 1] = r * np.sin(phi) * np.sin(theta)
-        positions[..., 2] = r * np.cos(phi)
+        positions[..., 0] = a * r * np.sin(phi) * np.cos(theta)
+        positions[..., 1] = b * r * np.sin(phi) * np.sin(theta)
+        positions[..., 2] = c * r * np.cos(phi)
         
-        return apply_affine_transformation_to_points(positions, self.basis)
+        return self.transformation.apply(
+            positions.reshape(-1, 3) # flatten into (n_theta*n_phi)x3 array to allow RigidTransform.apply() to digest it
+        ).reshape(n_theta, n_phi, 3) # ...then repackage into mesh for convenient plotting
     
-class Sphere(Ellipsoid[Numeric]):
+    
+class Sphere(Ellipsoid[Numeric]): # TODO: reimplement as separate from Ellipsoid
+    # TODO: address creation from axes (https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem)
     '''A spherical body with arbitrary radius and center'''
-    def __init__(self, radius : float=1.0, center : np.ndarray[Shape[3], Numeric]=None) -> 'Sphere':
-        super().__init__(affine_matrix_from_linear_and_center(
-            matrix=radius * np.eye(3, dtype=float),
+    def __init__(self,
+        radius : float=1.0,
+        center : np.ndarray[Shape[3], Numeric]=None,
+        orientation : Rotation=Rotation.identity(),
+    ) -> 'Sphere':
+        super().__init__(
+            radii=np.array([radius, radius, radius]),
             center=center,
-        ))
+            orientation=orientation,
+        )
         self.radius = radius
-        self.center = center
-    
+        
     def __repr__(self):
         return f'Sphere(r={self.radius})'
-    
-    # TODO: address creation from axes (https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem)
     
     # NOTE: affine transformations will produce Ellipsoid instances, as one would expect

--- a/mupt/geometry/shapes.py
+++ b/mupt/geometry/shapes.py
@@ -170,7 +170,7 @@ class Ellipsoid(BoundedShape[Numeric]):
     def is_valid_ellipsoid_matrix(basis : np.ndarray[Shape[4, 4], Numeric]) -> bool:
         '''Check that an affine matrix could represent an ellipsoid'''
         assert basis.shape == (4, 4)
-        axes, center, projective_part, w = basis[:-1, :-1], basis[:-1, -1], basis[-1, :-1], basis[-1, -1] # TODO: find more leegant way to do this splitting
+        axes, center, projective_part, w = basis[:-1, :-1], basis[:-1, -1], basis[-1, :-1], basis[-1, -1] # TODO: find more elegant way to do this splitting
         
         return bool(
             is_columnspace_mutually_orthogonal(axes) # ensure principal axes are mutually orthogonal

--- a/mupt/geometry/shapes.py
+++ b/mupt/geometry/shapes.py
@@ -86,17 +86,9 @@ class BoundedShape(ABC, Generic[Numeric]): # template for numeric type (some ite
         ... 
         
     @abstractmethod
-    def _apply_affine_transformation(self, affine_matrix : np.ndarray[Shape[N, N], Numeric]) -> 'BoundedShape':
-        '''Implemenation of how the body should actually apply an affine transformation matrix'''
-        ...
-
     def affine_transformation(self, affine_matrix : np.ndarray[Shape[N, N], Numeric]) -> 'BoundedShape':
-        '''
-        Apply an affine transformation to the body, as encoded by a transformation matrix
-        Matrix should be square and have dimension exactly one greater that that of the body
-        '''
-        assert(affine_matrix.shape == (self.dimension + 1, self.dimension + 1)) # enforce squareness and dimensionality of transform
-        return self._apply_affine_transformation(affine_matrix)
+        '''Apply a rigid transformation to the body'''
+        ...
      
     # @abstractmethod
     # def support(self, direction : np.ndarray[Shape[Dims], Numeric]) -> np.ndarray[Shape[Dims], Numeric]:
@@ -136,7 +128,7 @@ class PointCloud(BoundedShape[Numeric]):
     def contains(self, point : np.ndarray[Shape[3], Numeric]) -> bool:
         return (self.triangulation.find_simplex(point) != -1).astype(object) # need to cast from numpy bool to Python bool
     
-    def _apply_affine_transformation(self, affine_matrix : np.ndarray[Shape[4, 4], Numeric]) -> 'PointCloud':
+    def affine_transformation(self, affine_matrix : np.ndarray[Shape[4, 4], Numeric]) -> 'PointCloud':
         return PointCloud(
             positions=apply_affine_transformation_to_points(self.positions, affine_matrix)
         )
@@ -222,7 +214,7 @@ class Ellipsoid(BoundedShape[Numeric]):
             axis=-1,
         ) < 1).astype(object) # need to cast from numpy bool to Python bool
     
-    def _apply_affine_transformation(self, affine_matrix : np.ndarray[Shape[4, 4], Numeric]) -> 'Ellipsoid':
+    def affine_transformation(self, affine_matrix : np.ndarray[Shape[4, 4], Numeric]) -> 'Ellipsoid':
         return Ellipsoid(affine_matrix @ self.basis)
     
     # visualization
@@ -265,7 +257,7 @@ class Ellipsoid(BoundedShape[Numeric]):
             0.0:np.pi:n_phi*1j,
         ] # (magnitude of) complex step size is interpreted by numpy as a number of points
 
-        positions = np.zeros((n_theta, n_phi, 3), dtype=Numeric)
+        positions = np.zeros((n_theta, n_phi, 3), dtype=float)
         positions[..., 0] = r * np.sin(phi) * np.cos(theta)
         positions[..., 1] = r * np.sin(phi) * np.sin(theta)
         positions[..., 2] = r * np.cos(phi)

--- a/mupt/geometry/transforms/__init__.py
+++ b/mupt/geometry/transforms/__init__.py
@@ -1,1 +1,4 @@
-''''''
+'''Methods for representing and applying common transformations from various continuous spatial groups'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'

--- a/mupt/geometry/transforms/affine.py
+++ b/mupt/geometry/transforms/affine.py
@@ -1,4 +1,4 @@
-'''Application and construction of common affine transformations of points in 3D space'''
+'''Application and construction of common affine transformations'''
 
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'

--- a/mupt/geometry/transforms/affine/__init__.py
+++ b/mupt/geometry/transforms/affine/__init__.py
@@ -1,0 +1,27 @@
+'''
+Transformations from the more general affine group, which allows scaling, origin shifts, and projections,
+as well as utilities from converting to and from homogeneous coordinates.
+'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+from .matrices import (
+    AffineMatrix4x4,
+    affine_matrix_from_linear_and_center,
+    translation,
+    scaling,
+    rotation_x,
+    rotation_y,
+    rotation_z,
+    rotation_random,
+)
+from.homogeneous import (
+    to_homogeneous_coords,
+    from_homogeneous_coords,
+)
+from .application import (
+    AffineTransformable,
+    apply_affine_transformation_to_points,
+    apply_affine_transformation_recursive,
+)

--- a/mupt/geometry/transforms/affine/application.py
+++ b/mupt/geometry/transforms/affine/application.py
@@ -12,7 +12,6 @@ from .homogeneous import from_homogeneous_coords, to_homogeneous_coords
 from ...arraytypes import Shape, Numeric, N, Dims, DimsPlus
 
 
-# INTERFACES FOR TRANFORMABLE OBJECTS
 @runtime_checkable
 class AffineTransformable(Protocol):
     '''Interface for objects that can undergo an affine transformation'''

--- a/mupt/geometry/transforms/affine/application.py
+++ b/mupt/geometry/transforms/affine/application.py
@@ -1,0 +1,85 @@
+'''Utilities for applying affine transformations to other objects (not necessarily just points!)'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+from typing import Any, Literal, Mapping, Optional, Sequence, Union
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+from .homogeneous import from_homogeneous_coords, to_homogeneous_coords
+from ...arraytypes import Shape, Numeric, N, Dims, DimsPlus
+
+
+# INTERFACES FOR TRANFORMABLE OBJECTS
+@runtime_checkable
+class AffineTransformable(Protocol):
+    '''Interface for objects that can undergo an affine transformation'''
+    def affine_transformation(self, transformation: np.ndarray[Shape[N, N], float]) -> Any: 
+        # DEVNOTE: regarding typehints, returned type may be different to type of self, and is not necessarily transformable either
+        ...
+
+def apply_affine_transformation_recursive(
+        obj : Union[object, Sequence[Any], Mapping[str, Any]],
+        affine_matrix : np.ndarray[Shape[N, N], float],
+    ) -> Union[object, Sequence[Any], dict[str, Any]]:
+    '''Apply an affine transformation to an object, if it supports such a transformation,
+    and, if the object is a Sequence or Mapping, attempt to transform its members recursively
+    
+    Parameters
+    ----------
+    obj : Any
+        The object to be transformed, which may be a single object, a Sequence, or a Mapping
+    affine_matrix : Array[[N, N], float]
+        The affine transformation matrix to apply to the object
+        
+    Returns
+    -------
+    Any
+        The transformed object, which (depending on the transformability of the input
+        and its members and the return type of the transform method of members),
+        may or many not be of the same type as the initial object
+    '''
+    # top-level application check
+    if isinstance(obj, AffineTransformable):
+        obj = obj.affine_transformation(affine_matrix)
+        
+    # recursive iteration, as necessary
+    if isinstance(obj, Sequence):  # DEVNOTE: specifically opted for Sequence over Iterable here to avoid double-covering Mappings and unpacking generators
+        return type(obj)( # DEVNOTE: most common Sequence types (e.g. tuple, str, list) support init from comprehension; may revisit if this is not always the case
+            apply_affine_transformation_recursive(value, affine_matrix)
+                for value in obj
+        ) 
+    elif isinstance(obj, Mapping):
+        return {
+            key : apply_affine_transformation_recursive(value, affine_matrix)
+                for (key, value) in obj.items()
+        }
+        
+    return obj
+
+def apply_affine_transformation_to_points(
+        positions : np.ndarray[Shape[Any, Dims], Numeric],
+        transform : np.ndarray[Shape[DimsPlus, DimsPlus], Numeric],
+    ) -> np.ndarray[Shape[Any, Dims], Numeric]:
+    '''
+    Take a vector of coordinates in D dimensions, apply a [D + 1] dimensional affine
+    transformation, then project back down to D dimensions and return the output
+    
+    Parameters
+    ----------
+    positions : Array[[..., D], Numeric]
+        An array of points in D-dimensional space
+        Can be nested to any level of depth, as long as the last dimension is D
+    transform : Array[[D + 1, D + 1], Numeric]
+        A [D + 1] dimensional affine transformation matrix      
+        
+    Returns
+    -------
+    Array[[..., D], Numeric]
+        An array of the transformed points in D-dimensional space
+        Has the same shape as the input
+    '''
+    # TODO: check that matrix is compatible shape
+    return from_homogeneous_coords(to_homogeneous_coords(positions) @ transform.T)

--- a/mupt/geometry/transforms/affine/homogeneous.py
+++ b/mupt/geometry/transforms/affine/homogeneous.py
@@ -4,7 +4,7 @@ __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
 import numpy as np
-from ..arraytypes import Shape, N, M, Dims, DimsPlus, Numeric
+from ...arraytypes import Shape, N, M, Dims, DimsPlus, Numeric
 
 
 def to_homogeneous_coords(positions : np.ndarray[Shape[N, Dims], Numeric], projection : float=1.0) -> np.ndarray[Shape[N, DimsPlus], Numeric]:
@@ -19,3 +19,4 @@ def from_homogeneous_coords(positions : np.ndarray[Shape[N, DimsPlus], Numeric])
     '''Project down from an array of N points in [D + 1] dimensions to an array
     of N points in D dimensions, normalizing out by the homogeneous coordinate'''
     return positions[..., :-1] / positions[..., -1, None] # strip off and normalize by the projective part (via broadcast)
+

--- a/mupt/geometry/transforms/affine/matrices.py
+++ b/mupt/geometry/transforms/affine/matrices.py
@@ -1,94 +1,16 @@
-'''Application and construction of common affine transformations'''
+'''Affine matrices which realize many common affine transformations'''
 
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Any, Literal, Mapping, Optional, Sequence, Union
-from typing import Protocol, runtime_checkable
-
+from typing import Literal, Optional, Union
 import numpy as np
 
-from ..arraytypes import Shape, Numeric, N, Dims, DimsPlus
+from ...arraytypes import Shape, Numeric, Dims, DimsPlus
 type AffineMatrix4x4 = np.ndarray[Shape[Literal[4], Literal[4]], Numeric]
 
-from ..coordinates.homogeneous import from_homogeneous_coords, to_homogeneous_coords
 
 
-# INTERFACES FOR TRANFORMABLE OBJECTS
-@runtime_checkable
-class AffineTransformable(Protocol):
-    '''Interface for objects that can undergo an affine transformation'''
-    def affine_transformation(self, transformation: np.ndarray[Shape[N, N], float]) -> Any: 
-        # DEVNOTE: regarding typehints, returned type may be different to type of self, and is not necessarily transformable either
-        ...
-
-def apply_affine_transform_recursive(
-        obj : Union[object, Sequence[Any], Mapping[str, Any]],
-        affine_matrix : np.ndarray[Shape[N, N], float],
-    ) -> Union[object, Sequence[Any], dict[str, Any]]:
-    '''Apply an affine transformation to an object, if it supports such a transformation,
-    and, if the object is a Sequence or Mapping, attempt to transform its members recursively
-    
-    Parameters
-    ----------
-    obj : Any
-        The object to be transformed, which may be a single object, a Sequence, or a Mapping
-    affine_matrix : Array[[N, N], float]
-        The affine transformation matrix to apply to the object
-        
-    Returns
-    -------
-    Any
-        The transformed object, which (depending on the transformability of the input
-        and its members and the return type of the transform method of members),
-        may or many not be of the same type as the initial object
-    '''
-    # top-level application check
-    if isinstance(obj, AffineTransformable):
-        obj = obj.affine_transformation(affine_matrix)
-        
-    # recursive iteration, as necessary
-    if isinstance(obj, Sequence):  # DEVNOTE: specifically opted for Sequence over Iterable here to avoid double-covering Mappings and unpacking generators
-        return type(obj)( # DEVNOTE: most common Sequence types (e.g. tuple, str, list) support init from comprehension; may revisit if this is not always the case
-            apply_affine_transform_recursive(value, affine_matrix)
-                for value in obj
-        ) 
-    elif isinstance(obj, Mapping):
-        return {
-            key : apply_affine_transform_recursive(value, affine_matrix)
-                for (key, value) in obj.items()
-        }
-        
-    return obj
-    
-
-# APPLICATION OF AFFINE TRANSFORMATIONS
-def apply_affine_transformation_to_points(
-        positions : np.ndarray[Shape[Any, Dims], Numeric],
-        transform : np.ndarray[Shape[DimsPlus, DimsPlus], Numeric],
-    ) -> np.ndarray[Shape[Any, Dims], Numeric]:
-    '''
-    Take a vector of coordinates in D dimensions, apply a [D + 1] dimensional affine
-    transformation, then project back down to D dimensions and return the output
-    
-    Parameters
-    ----------
-    positions : Array[[..., D], Numeric]
-        An array of points in D-dimensional space
-        Can be nested to any level of depth, as long as the last dimension is D
-    transform : Array[[D + 1, D + 1], Numeric]
-        A [D + 1] dimensional affine transformation matrix      
-        
-    Returns
-    -------
-    Array[[..., D], Numeric]
-        An array of the transformed points in D-dimensional space
-        Has the same shape as the input
-    '''
-    # TODO: check that matrix is compatible shape
-    return from_homogeneous_coords(to_homogeneous_coords(positions) @ transform.T)
-
-# CONSTRUCTION OF AFFINE MATRICES
 def affine_matrix_from_linear_and_center(
         matrix : np.ndarray[Shape[Dims, Dims], Numeric],
         center : Optional[np.ndarray[Shape[Dims], Numeric]]=None,
@@ -301,3 +223,5 @@ def rotation_random(about_x : bool=True, about_y : bool=True, about_z : bool=Tru
             matrix = rot_fn(2 * np.pi * np.random.rand(), dtype=dtype) @ matrix # generate random angle and multiply rotation into overall transform matrix (in order)
 
     return matrix
+
+# TODO: define shear transforms

--- a/mupt/geometry/transforms/linear.py
+++ b/mupt/geometry/transforms/linear.py
@@ -57,8 +57,8 @@ def orthogonalizer(direction_vector : np.ndarray[Shape[Dims], Numeric]) -> np.nd
     ) 
 cross = orthogonalizer
 
-# DEVNOTE: should type annotations be for general dimension? (i.e. not just 3 where the cross product is well-defined?)
 def rotator(direction_vector : np.ndarray[Shape[Dims], Numeric], angle_rad : float=0.0) -> np.ndarray[Shape[Dims, Dims], Numeric]:
+    # DEVNOTE: should type annotations be for general dimension? (i.e. not just 3 where the cross product is well-defined?)
     ''' 
     Computes a linear transformation which, when applied to an arbitrary vector,
     rotates that vector by "angle_rad" radians around the axis defined by "direction_vector"

--- a/mupt/geometry/transforms/linear.py
+++ b/mupt/geometry/transforms/linear.py
@@ -1,4 +1,4 @@
-'''Application and construction of common linear transformations of points in 3D space'''
+'''Application and construction of common linear transformations'''
 
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'

--- a/mupt/geometry/transforms/rigid.py
+++ b/mupt/geometry/transforms/rigid.py
@@ -3,5 +3,53 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-import numpy as np
-from scipy.spatial.transform import Rotation, RigidTransform
+from typing import Any, Mapping, Sequence, Union
+from typing import Protocol, runtime_checkable
+
+from scipy.spatial.transform import RigidTransform
+
+
+@runtime_checkable
+class RigidTransformable(Protocol):
+    '''Interface for objects that can undergo a rigid (isometric) transformation'''
+    def apply_rigid_transformation(self, transformation: RigidTransform) -> Any: 
+        # DEVNOTE: regarding typehints, returned type may be different to type of self, and is not necessarily transformable either
+        ...
+
+def apply_rigid_transformation_recursive(
+        obj : Union[object, Sequence[Any], Mapping[str, Any]],
+        transformation: RigidTransform,
+    ) -> Union[object, Sequence[Any], dict[str, Any]]:
+    '''Apply a rigid transformation to an object, if it supports such a transformation, and
+    if the object is a Sequence or Mapping, attempt to transform its members recursively
+    
+    Parameters
+    ----------
+    obj : Any
+        The object to be transformed, which may be a single object, a Sequence, or a Mapping
+    rigid_transform : RigidTransform
+        The rigid transformation to apply to the object
+
+    Returns
+    -------
+    Any
+        The transformed object, which (depending on the transformability and return types of
+        the input and its members) may or many not be of the same type as the initial object
+    '''
+    # top-level application check
+    if isinstance(obj, RigidTransformable):
+        obj = obj.apply_rigid_transformation(transformation)
+
+    # recursive iteration, as necessary
+    if isinstance(obj, Sequence):  # DEVNOTE: specifically opted for Sequence over Iterable here to avoid double-covering Mappings and unpacking generators
+        return type(obj)( # DEVNOTE: most common Sequence types (e.g. tuple, str, list) support init from comprehension; may revisit if this is not always the case
+            apply_rigid_transformation_recursive(value, transformation)
+                for value in obj
+        ) 
+    elif isinstance(obj, Mapping):
+        return {
+            key : apply_rigid_transformation_recursive(value, transformation)
+                for (key, value) in obj.items()
+        }
+        
+    return obj

--- a/mupt/geometry/transforms/rigid.py
+++ b/mupt/geometry/transforms/rigid.py
@@ -1,0 +1,7 @@
+'''Utilities for representing and applying rigid transformations to points in 3D space (i.e. working with the Euclidean isometry group E(3))'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+import numpy as np
+from scipy.spatial.transform import Rotation, RigidTransform

--- a/mupt/mupr/ports.py
+++ b/mupt/mupr/ports.py
@@ -10,7 +10,6 @@ import numpy as np
 from rdkit import Chem
 from rdkit.Chem.rdchem import Mol, BondType
 
-from ..mutils.decorators.functional import optional_in_place
 from ..geometry.arraytypes import Shape, Dims, DimsPlus
 from ..geometry.transforms.linear import reflector, rotator
 from ..geometry.transforms.affine import (

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -33,7 +33,7 @@ from ..chemistry.selection import (
 )
 from ..geometry.arraytypes import ndarray, N, Shape
 from ..geometry.shapes import BoundedShape, PointCloud, Sphere
-from ..geometry.transforms.affine import apply_affine_transform_recursive
+from ..geometry.transforms.affine import apply_affine_transformation_recursive
 
 
 @dataclass
@@ -224,7 +224,7 @@ class Primitive:
     # geometric methods
     def affine_transformation(self, affine_matrix : np.ndarray[Shape[N, N], float]) -> 'Primitive':
         '''Apply an affine transformation to all parts of a Primitive which support it'''
-        return Primitive(**apply_affine_transform_recursive(self.__dict__, affine_matrix))
+        return Primitive(**apply_affine_transformation_recursive(self.__dict__, affine_matrix))
 
 
 @dataclass

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -3,11 +3,12 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Any, Generator, Hashable, Optional, Sequence, Union
+from typing import Any, Generator, Hashable, Optional
 from dataclasses import dataclass, field
 from enum import Enum # consider having a bitwise Enum to encode possible specification states of a primitive??
 
-import numpy as np
+import numpy as np # TODO: deprecate use of numpy for bitmasks; all array operations should be handled outside of this module!
+from scipy.spatial.transform import RigidTransform
 
 from rdkit import Chem
 from rdkit.Chem.rdchem import (
@@ -33,7 +34,7 @@ from ..chemistry.selection import (
 )
 from ..geometry.arraytypes import ndarray, N, Shape
 from ..geometry.shapes import BoundedShape, PointCloud, Sphere
-from ..geometry.transforms.affine import apply_affine_transformation_recursive
+from ..geometry.transforms.rigid import apply_rigid_transformation_recursive
 
 
 @dataclass
@@ -222,9 +223,9 @@ class Primitive:
             yield sub_primitive
             
     # geometric methods
-    def affine_transformation(self, affine_matrix : np.ndarray[Shape[N, N], float]) -> 'Primitive':
-        '''Apply an affine transformation to all parts of a Primitive which support it'''
-        return Primitive(**apply_affine_transformation_recursive(self.__dict__, affine_matrix))
+    def apply_rigid_transformation(self, transform : RigidTransform) -> 'Primitive':
+        '''Apply an isometric (i.e. rigid) transformation to all parts of a Primitive which support it'''
+        return Primitive(**apply_rigid_transformation_recursive(self.__dict__, transform))
 
 
 @dataclass

--- a/mupt/tests/geometry/__init__.py
+++ b/mupt/tests/geometry/__init__.py
@@ -1,4 +1,4 @@
-'''Unit tests for the mupt.geometry.coordinates.basis module'''
+'''Unit tests for the mupt.geometry module'''
 
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'

--- a/mupt/tests/geometry/test_basis.py
+++ b/mupt/tests/geometry/test_basis.py
@@ -1,0 +1,80 @@
+'''Unit tests for basis coordinate operations'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+import pytest
+import numpy as np
+
+from mupt.geometry.arraytypes import Shape, N
+from mupt.geometry.coordinates.basis import (
+    is_rowspace_mutually_orthogonal,
+    is_columnspace_mutually_orthogonal,
+    is_orthonormal,
+)
+
+
+# Test matrices for orthogonality checks
+ORTHO_ROWS_ONLY = np.array([
+    [ 1,  2,  3],
+    [ 2,  2, -2],
+    [ 5, -4,  1]
+]) # an example of a matrix whose rows are mutually orthogonal but whose columns are not
+ORTHO_COLS_ONLY = np.array([
+    [ 1,  2,  5],
+    [ 2,  2, -4],
+    [ 3, -2,  1]
+]) # an example of a matrix whose columns are mutually orthogonal but whose rows are not
+RECTANGULAR = np.array([
+    [1, -3, 0, 2],
+    [4, 0, 3, -2],
+]) # rowspace and columnspace checks should also work for nonsquare matrices - this one has orthogonal rows, but not columns
+IDENTITY = np.eye(3) # identity matrix is orthogonal by definition
+ROTATION = np.array([
+    [np.cos(np.pi/3), -np.sin(np.pi/3), 0],
+    [np.sin(np.pi/3),  np.cos(np.pi/3), 0],
+    [0,                0,               1],
+]) # by definition, proper rotation matrices are orthonormal
+
+
+@pytest.mark.parametrize(
+    'matrix, expected_value',
+    [
+        (ORTHO_ROWS_ONLY, True),
+        (ORTHO_COLS_ONLY, False),
+        (RECTANGULAR, True),
+        (ROTATION, True),
+        (IDENTITY, True),
+    ]
+)
+def test_rowspace_orthogonality_check(matrix : np.ndarray[Shape[N, N], float], expected_value : bool) -> None:
+    '''Test that the row space orthogonality check works as expected'''
+    assert is_rowspace_mutually_orthogonal(matrix) == expected_value
+    
+@pytest.mark.parametrize(
+    'matrix, expected_value',
+    [
+        (ORTHO_ROWS_ONLY, False),
+        (ORTHO_COLS_ONLY, True),
+        (RECTANGULAR, False),
+        (ROTATION, True),
+        (IDENTITY, True),
+    ]
+)
+def test_columnspace_orthogonality_check(matrix : np.ndarray[Shape[N, N], float], expected_value : bool) -> None:
+    '''Test that the column space orthogonality check works as expected'''
+    assert is_columnspace_mutually_orthogonal(matrix) == expected_value
+
+@pytest.mark.parametrize(
+    'matrix, expected_value',
+    [
+        (ORTHO_ROWS_ONLY, False),
+        (ORTHO_COLS_ONLY, False),
+        (RECTANGULAR, False),
+        (ROTATION, True),
+        (IDENTITY, True),
+    ]
+)
+def test_orthonormality_check(matrix : np.ndarray[Shape[N, N], float], expected_value : bool) -> None:
+    '''Test that the orthonormality check works as expected'''
+    assert is_orthonormal(matrix) == expected_value

--- a/mupt/tests/geometry/test_homogeneous.py
+++ b/mupt/tests/geometry/test_homogeneous.py
@@ -7,7 +7,7 @@ import pytest
 from typing import Any
 import numpy as np
 
-from mupt.geometry.coordinates.homogeneous import (
+from mupt.geometry.transforms.affine.homogeneous import (
     to_homogeneous_coords,
     from_homogeneous_coords,
 )


### PR DESCRIPTION
## Description
Converting overly-general affine transformations to scipy's new RigidTransforms in geometric operations on core repr objects

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Replace affine transformation capabilities with analogous rigid behavior on:
    - [x] BoundedShape and child classes
    - [x] Port
    - [x] Primitive
  - [x] Reorganize .geometry, paring down basis and affine submodules
