### PR TITLE
Add AI & Authorship Policy document

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,6 +34,10 @@ describes how to merge code changes into this mupt.
   integration returns checkmarks,
   and multiple core developers give "Approved" reviews.
 
+# Coding Standards 
+
+To be added
+
 # Additional Resources
 
 * [General GitHub documentation](https://help.github.com/)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,71 @@
+# MuPT Repository Instructions
+
+This file provides instructions for GitHub Copilot when working with code in this repository.
+
+## Coding Standards
+
+Follow the coding standards and best practices defined in [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards).
+
+## AI Policy
+
+**CRITICAL**: All contributions must comply with the [AI_POLICY.md](AI_POLICY.md). Review that document for complete requirements.
+
+### Core Principles:
+- Code and comments must not be direct, unreviewed outputs of AI agents
+- All AI-assisted contributions require human oversight and validation
+- Ensure code logic reflects genuine understanding, not copied AI output
+- The submitter is the Sole Responsible Author for every line of code
+
+## Instructions for AI Reviewers (Copilot / CodeRabbit)
+
+AI-based reviewers (e.g. GitHub Copilot, CodeRabbit) must follow the repository's AI usage policy and review rules.
+
+For the complete and authoritative AI reviewer instructions, see [AI_POLICY.md](AI_POLICY.md), section 3.
+
+When generating or reviewing suggestions, prefer:
+- Enforcing the coding standards in [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards)
+- Enforcing the AI usage rules and review heuristics defined in [AI_POLICY.md](AI_POLICY.md)
+- Highlighting missing tests, missing proof of local execution, and misuse of `kornia` vs. raw PyTorch utilities
+## Key Guidelines
+
+- **Code style**: Follow PEP8, use 120 character line length, Ruff linting, and f-strings
+- **Type hints**: Required for all function inputs and outputs
+- **Documentation**: Follow documentation and docstring guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards) and match the existing codebase style
+- **Use MuPT**: Always prefer `kornia` utilities over raw PyTorch functions
+
+## Review Checklist
+
+When reviewing code changes, verify:
+
+- Code and comments are not direct, unreviewed AI agent outputs
+- Code follows guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)
+- Code complies with [AI_POLICY.md](AI_POLICY.md)
+- Tests are included for new functionality
+- Code passes `pixi run lint` and `pixi run typecheck`
+- PR includes proof of local test execution (test logs)
+- Code uses `kornia` utilities instead of reinventing existing functionality
+- Comments are written in English and verified by a human with a good understanding of the code
+
+## PR-Issue Alignment Review
+
+When reviewing pull requests, ensure strict alignment with the linked issue:
+
+1. **Issue Link Verification**:
+   - Verify the PR description contains a valid issue reference (e.g., "Fixes #123" or "Closes #123")
+   - Confirm the linked issue exists and is open (or was open when the PR was created)
+
+2. **Assignment Verification**:
+   - Check that the PR author is assigned to the linked issue
+   - If not assigned, request that a maintainer assign the issue before proceeding with review
+
+3. **Scope Matching**:
+   - **Critical**: Verify that the PR implementation strictly matches what the issue describes
+   - The PR should not include changes beyond the scope of the linked issue
+   - If the PR includes additional features or changes not mentioned in the issue, request that those be split into separate issues/PRs
+   - Compare the PR description, code changes, and tests against the issue description to ensure alignment
+
+4. **Issue Approval Status**:
+   - Verify the linked issue has been reviewed and approved by a maintainer
+   - Issues with the `triage` label may not have been fully reviewed yet
+
+**Reviewer Action**: If the PR does not match the issue scope or requirements, clearly explain the mismatch and request that the PR be updated to strictly align with the issue, or that additional changes be moved to separate issues/PRs.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,13 +25,13 @@ For the complete and authoritative AI reviewer instructions, see [AI_POLICY.md](
 When generating or reviewing suggestions, prefer:
 - Enforcing the coding standards in [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards)
 - Enforcing the AI usage rules and review heuristics defined in [AI_POLICY.md](AI_POLICY.md)
-- Highlighting missing tests, missing proof of local execution, and misuse of `kornia` vs. raw PyTorch utilities
+- Highlighting missing tests, missing proof of local execution, and misuse of `mupt` vs. raw numpy/other package re-implementations
 ## Key Guidelines
 
 - **Code style**: Follow PEP8, use 120 character line length, Ruff linting, and f-strings
 - **Type hints**: Required for all function inputs and outputs
 - **Documentation**: Follow documentation and docstring guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards) and match the existing codebase style
-- **Use MuPT**: Always prefer `kornia` utilities over raw PyTorch functions
+- **Use MuPT**: Always prefer `mupt` utilities over raw PyTorch functions
 
 ## Review Checklist
 
@@ -43,7 +43,7 @@ When reviewing code changes, verify:
 - Tests are included for new functionality
 - Code passes `pixi run lint` and `pixi run typecheck`
 - PR includes proof of local test execution (test logs)
-- Code uses `kornia` utilities instead of reinventing existing functionality
+- Code uses `mupt` utilities instead of reinventing existing functionality
 - Comments are written in English and verified by a human with a good understanding of the code
 
 ## PR-Issue Alignment Review

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,79 @@
+# 🤖 MuPT AI & Authorship Policy
+
+**Version:** 1.0
+**Enforcement:** Strict
+**Applicability:** All Pull Requests (Human & Bot)
+
+## 1. Core Philosophy
+
+MuPT accepts AI-assisted code (e.g., using Copilot, Cursor, etc.), but strictly rejects AI-generated contributions where the submitter acts merely as a proxy. The submitter is the **Sole Responsible Author** for every line of code, comment, and design decision.
+
+## 2. The 3 Laws of Contribution
+
+### Law 1: Proof of Verification
+
+AI tools frequently write code that looks correct but fails execution. Therefore, "vibe checks" are insufficient.
+
+**Requirement:** Every PR introducing functional changes must include a pasted snippet of the local test logs (e.g., `pixi run test ...`). This is mandatory for all contributors and is particularly important for first-time contributors.
+
+**Failure Condition:** If a PR lacks execution proof and contains complex logic, it will be flagged as **Unverified**.
+
+**Requirement:** All PRs must be previously discussed in via a [GitHub issue](https://github.com/MuPT-hub/mupt/issues) before implementation. The PR must reference the discussion or issue.
+
+**Requirement:** Implementations must be based on an existing library reference (e.g., PyTorch, OpenCV, scikit-image, etc.) that must be provided in the PR description for verification. This reference serves as proof that the implementation follows established algorithms and is not hallucinated.
+
+### Law 2: The Hallucination & Redundancy Ban
+
+AI models often hallucinate comments or reinvent existing utilities.
+
+**Requirement:** You must use existing `mupt` utilities and never reinvent the wheel, except for when the utility is not available.
+
+**Failure Condition:** Creating new helper functions (e.g., `def warp_affine...`) when a MuPT equivalent exists is grounds for immediate rejection.
+
+**Failure Condition:** "Ghost Comments" (comments explaining logic that was deleted or doesn't exist) will result in a request for a full manual rewrite. Redundant comments are not allowed. Example: "This function returns the input tensor".
+
+### Law 3: The "Explain It" Standard
+
+**Requirement:** If a maintainer or reviewer asks during code review, you must be able to derive the math or explain the logic of any function you submit.
+
+**Failure Condition:** Answering a review question with "That's what the AI outputted" or "I don't know, it works" leads to immediate closure.
+
+### Law 4: Transparency in AI Usage Disclosure
+
+**Requirement:** All PRs must accurately complete the "AI Usage Disclosure" section in the pull request template. This disclosure is mandatory and must reflect the actual use of AI tools.
+
+**When to mark as 🔴 AI-generated:**
+- An AI agent (e.g., Cursor, GitHub Copilot, ChatGPT, etc.) generated the code, PR description, or commit messages
+- You cannot explain the logic without referring to the AI's output
+- The PR was created primarily by an agent with minimal human review or modification
+
+**When to mark as 🟡 AI-assisted:**
+- You used AI tools for boilerplate code, refactoring, or suggestions, but you manually reviewed and tested every line
+- You understand and can explain all the code you're submitting
+- You made significant modifications to AI-suggested code
+
+**When to mark as 🟢 No AI used:**
+- You wrote all code manually without any AI assistance
+
+**Failure Condition:** Incorrectly marking AI-generated code as "AI-assisted" or "No AI used" may result in PR closure, especially if the code contains hallucinations or cannot be explained during review.
+
+## 3. Instructions for AI Reviewers (Copilot / CodeRabbit)
+
+If you are an AI agent (GitHub Copilot, CodeRabbit, etc.) reviewing a PR for MuPT, you must follow the repository's dedicated reviewer instructions.
+
+The **canonical and up-to-date instructions for AI reviewers** are maintained in [`.github/copilot-instructions.md`](.github/copilot-instructions.md). That document defines:
+
+- The expected reviewer persona and responsibilities
+- The checks to perform on PR descriptions, code, tests, and comments
+- The required enforcement of the laws defined in this `AI_POLICY.md`
+
+
+Any other document (including this one) should treat `copilot-instructions.md` as the single source of truth for AI reviewer behaviour. When updating reviewer logic, update `copilot-instructions.md` first and, if needed, adjust references here.
+
+This section exists to link AI reviewers to the canonical instructions and to make clear that those instructions must enforce the policies defined in Sections 1 and 2 above.
+
+## 4. Additional Resources
+
+For comprehensive guidance on contributing to MuPT, including development workflows, code quality standards, testing practices, and AI-assisted development best practices, see the [Best Practices section](CONTRIBUTING.md#best-practices) in `CONTRIBUTING.md`.
+
+This document developed based on policies developed at https://github.com/kornia/kornia/AI_POLICY.md

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -14,7 +14,7 @@ MuPT accepts AI-assisted code (e.g., using Copilot, Cursor, etc.), but strictly 
 
 AI tools frequently write code that looks correct but fails execution. Therefore, "vibe checks" are insufficient.
 
-**Requirement:** Every PR introducing functional changes must include a pasted snippet of the local test logs (e.g., `pixi run test ...`). This is mandatory for all contributors and is particularly important for first-time contributors.
+**Requirement:** Every PR introducing functional changes must pass all tests that are currently extant. This is mandatory for all contributors and is particularly important for first-time contributors. All code with AI contributions must include tests to demonstrate their validity.
 
 **Failure Condition:** If a PR lacks execution proof and contains complex logic, it will be flagged as **Unverified**.
 
@@ -34,23 +34,30 @@ AI models often hallucinate comments or reinvent existing utilities.
 
 ### Law 3: The "Explain It" Standard
 
+**Requirement:** All pull requests messages and descriptions must be entirely authored by human. Individual commit methods may use AI tools to fully summarize the changes.
+
+**Failure Condtion:** If the PR is suspected to be AI, the submitters will be asked to rewrite the PR message from scrathc. 
+
 **Requirement:** If a maintainer or reviewer asks during code review, you must be able to derive the math or explain the logic of any function you submit.
 
 **Failure Condition:** Answering a review question with "That's what the AI outputted" or "I don't know, it works" leads to immediate closure.
+
 
 ### Law 4: Transparency in AI Usage Disclosure
 
 **Requirement:** All PRs must accurately complete the "AI Usage Disclosure" section in the pull request template. This disclosure is mandatory and must reflect the actual use of AI tools.
 
 **When to mark as 🔴 AI-generated:**
-- An AI agent (e.g., Cursor, GitHub Copilot, ChatGPT, etc.) generated the code, PR description, or commit messages
+- An AI agent (e.g., Cursor, GitHub Copilot, ChatGPT, etc.) generated the code or commit messages
 - You cannot explain the logic without referring to the AI's output
 - The PR was created primarily by an agent with minimal human review or modification
+- This should not currently submitted to MuPT
 
 **When to mark as 🟡 AI-assisted:**
 - You used AI tools for boilerplate code, refactoring, or suggestions, but you manually reviewed and tested every line
 - You understand and can explain all the code you're submitting
 - You made significant modifications to AI-suggested code
+- This code is appropriate for MuPT contribution
 
 **When to mark as 🟢 No AI used:**
 - You wrote all code manually without any AI assistance

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -36,7 +36,7 @@ AI models often hallucinate comments or reinvent existing utilities.
 
 **Requirement:** All pull requests messages and descriptions must be entirely authored by human. Individual commit methods may use AI tools to fully summarize the changes.
 
-**Failure Condtion:** If the PR is suspected to be AI, the submitters will be asked to rewrite the PR message from scrathc. 
+**Failure Condtion:** If the PR is suspected to be AI, the submitters will be asked to rewrite the PR message from scratch. 
 
 **Requirement:** If a maintainer or reviewer asks during code review, you must be able to derive the math or explain the logic of any function you submit.
 

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -20,7 +20,7 @@ AI tools frequently write code that looks correct but fails execution. Therefore
 
 **Requirement:** All PRs must be previously discussed in via a [GitHub issue](https://github.com/MuPT-hub/mupt/issues) before implementation. The PR must reference the discussion or issue.
 
-**Requirement:** Implementations must be based on an existing library reference (e.g., PyTorch, OpenCV, scikit-image, etc.) that must be provided in the PR description for verification. This reference serves as proof that the implementation follows established algorithms and is not hallucinated.
+**Failure Condition**: IF PR lacks reference to the appropriate issue, the user will be asked to rewrite the PR.
 
 ### Law 2: The Hallucination & Redundancy Ban
 


### PR DESCRIPTION
This document outlines the AI and authorship policy for MuPT, detailing the core philosophy, contribution laws, and requirements for AI usage disclosure.

## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go