### PR TITLE
Improved BoundedShapes and array typing

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run example notebook tests
         run: |
-          git clone -b better-shapes https://github.com/MuPT-hub/mupt-examples 
+          git clone https://github.com/MuPT-hub/mupt-examples 
           pushd mupt-examples
           source notebook_tests_master.sh
           popd

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run example notebook tests
         run: |
-          git clone https://github.com/MuPT-hub/mupt-examples
+          git clone -b better-shapes https://github.com/MuPT-hub/mupt-examples 
           pushd mupt-examples
           source notebook_tests_master.sh
           popd

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -4,57 +4,60 @@ __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
 from typing import (
-    Annotated,
-    Generic,
     Literal,
     Optional,
     TypeVar,
+    Union,
 )
 S = TypeVar('S') # pure generics
 T = TypeVar('T') # pure generics
 
 import numpy as np
 import numpy.typing as npt
-from numpy import ndarray
 from numbers import Number, Real
 
 
 # Numeric typehints
-Numeric = TypeVar('Numeric', bound=Number) # typehint a number-like generic type
-RealValued = TypeVar('RealValued', bound=Real)
+NumberLike = Union[np.number, Number, float] # DEV: stupidly, but "float" does not typehint as Number in static type checkers, so have to add it manually
+Numeric = TypeVar('Numeric', bound=Number)
+NumericNP = TypeVar('NumericNP', bound=np.dtype[np.number])
+
+# RealValued = TypeVar('RealValued', bound=Real)
+# RealValuedNP = TypeVar('RealValuedNP', bound=np.dtype[np.floating])
 
 # Numpy array type annotations
-Shape = tuple # the shape field of a numpy array
-DType = TypeVar('DType', bound=np.generic) # the data type of a numpy array
+Shape = tuple
+DType = TypeVar('DType', bound=np.dtype)
 
+## Typehints for indeterminate size of a given array dimension
+M = TypeVar('M', bound=int) 
+N = TypeVar('N', bound=int)
+P = TypeVar('P', bound=int)
 Dims = TypeVar('Dims', bound=int) # intended to typehint the number of dimensions
 DimsPlus = TypeVar('DimsPlus', bound=int) # intended to typehint the number of dimensions +1 (no easy way to do arithmetic to generic types yet)
-M = TypeVar('M', bound=int) # typehint the size of a given dimension
-N = TypeVar('N', bound=int) # typehint the size of a given dimension
-P = TypeVar('P', bound=int) # typehint the size of a given dimension
 
 # Fixed-size vector and array type annotations - consider deprecating, since they're not currently being used anywhere
 ## DEV: this type of hard-coding sucks, but is the best we can do with the current Python type system
-Vector2  = np.ndarray[Shape[Literal[2]], Numeric]
-Vector3  = np.ndarray[Shape[Literal[3]], Numeric]
-Vector4  = np.ndarray[Shape[Literal[4]], Numeric]
-VectorN  = np.ndarray[Shape[N], Numeric]
+Vector2  = np.ndarray[Shape[Literal[2]], NumericNP]
+Vector3  = np.ndarray[Shape[Literal[3]], NumericNP]
+Vector4  = np.ndarray[Shape[Literal[4]], NumericNP]
+VectorN  = np.ndarray[Shape[N], NumericNP]
 
-Array2x2 = np.ndarray[Shape[Literal[2], Literal[2]], Numeric]
-Array3x3 = np.ndarray[Shape[Literal[3], Literal[3]], Numeric]
-Array4x4 = np.ndarray[Shape[Literal[4], Literal[4]], Numeric]
+Array2x2 = np.ndarray[Shape[Literal[2], Literal[2]], NumericNP]
+Array3x3 = np.ndarray[Shape[Literal[3], Literal[3]], NumericNP]
+Array4x4 = np.ndarray[Shape[Literal[4], Literal[4]], NumericNP]
 
-ArrayNx2 = np.ndarray[Shape[N, Literal[2]], Numeric]
-ArrayNx3 = np.ndarray[Shape[N, Literal[3]], Numeric]
-ArrayNx4 = np.ndarray[Shape[N, Literal[4]], Numeric]
+ArrayNx2 = np.ndarray[Shape[N, Literal[2]], NumericNP]
+ArrayNx3 = np.ndarray[Shape[N, Literal[3]], NumericNP]
+ArrayNx4 = np.ndarray[Shape[N, Literal[4]], NumericNP]
 
-Array2xN = np.ndarray[Shape[Literal[2], N], Numeric]
-Array3xN = np.ndarray[Shape[Literal[3], N], Numeric]
-Array4xN = np.ndarray[Shape[Literal[4], N], Numeric]
+Array2xN = np.ndarray[Shape[Literal[2], N], NumericNP]
+Array3xN = np.ndarray[Shape[Literal[3], N], NumericNP]
+Array4xN = np.ndarray[Shape[Literal[4], N], NumericNP]
 
-ArrayNxN = np.ndarray[Shape[N, N], Numeric]
-ArrayNxM = np.ndarray[Shape[N, M], Numeric]
-ArrayMxN = np.ndarray[Shape[M, N], Numeric]
+ArrayNxN = np.ndarray[Shape[N, N], NumericNP]
+ArrayNxM = np.ndarray[Shape[N, M], NumericNP]
+ArrayMxN = np.ndarray[Shape[M, N], NumericNP]
 
 
 # vector comparison
@@ -68,8 +71,8 @@ def as_n_vector(vectorlike : np.ndarray[Shape[N], DType], n : N=3) -> np.ndarray
     return vectorlike.reshape(n)
 
 def compare_optional_positions(
-    position_1 : Optional[np.ndarray[Shape[N], float]],
-    position_2 : Optional[np.ndarray[Shape[N], float]],
+    position_1 : Optional[VectorN],
+    position_2 : Optional[VectorN],
     **kwargs,
 ) -> bool:
     '''Check that two positional values are either 1) both undefined, or 2) both defined and equal'''

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -66,14 +66,30 @@ TriangulationIndices = np.ndarray[Shape[N, Literal[3]], np.dtype[np.integer]]
 BitVectorN = np.ndarray[Shape[N], BoolNP]
 
 # vector comparison
-def as_n_vector(vectorlike : np.ndarray[Shape[N], DType], n : N=3) -> np.ndarray[Shape[N], DType]:
-    '''Interpret array as a 1D n-element vector''' 
+def as_n_vector(
+    vectorlike : VectorN | Array1xN | ArrayNx1,
+    dimension : int=3,
+    dtype : Optional[npt.DTypeLike]=None,
+) -> VectorN:
+    '''
+    Convert row vector, column vector, Nx1 array, or 1xN array into
+    1D column vector with appropriate dimension and data type
+    
+    Enables permissive ingestion of vector-shaped objects
+    '''
     if not isinstance(vectorlike, np.ndarray): # TODO: include support for list/tuple-like WITHOUT including sets, str, etc
         raise TypeError(f'Vectorlike must be a numpy array, not {type(vectorlike)}')
-    if len(vectorlike) != n:
-        raise ValueError(f'Expected {n}-element vectorlike, received {len(vectorlike)}-element array instead')
     
-    return vectorlike.reshape(n)
+    vector_column = np.atleast_2d(vectorlike).reshape(-1) # permits transposed and nested vector inputs
+    if vector_column.shape != (dimension,):
+        raise ValueError(
+            f'Expected vector with shape {(dimension,)}, got {vector_column.shape}'
+        )
+    
+    if dtype is not None:
+        vector_column = vector_column.astype(dtype)
+        
+    return vector_column
 
 def compare_optional_positions(
     position_1 : Optional[VectorN],

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -21,7 +21,7 @@ from numbers import Number, Real
 NumberLike = Union[np.number, Number, float] # DEV: stupidly, but "float" does not typehint as Number in static type checkers, so have to add it manually
 Numeric = TypeVar('Numeric', bound=Number)
 NumericNP = TypeVar('NumericNP', bound=np.dtype[np.number])
-BoolNP = TypeVar('BoolNP', bound=np.dtype[np.bool])
+BoolNP = TypeVar('BoolNP', bound=np.dtype[np.bool_])
 
 # RealValued = TypeVar('RealValued', bound=Real)
 # RealValuedNP = TypeVar('RealValuedNP', bound=np.dtype[np.floating])

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -9,12 +9,13 @@ from typing import (
     TypeVar,
     Union,
 )
-S = TypeVar('S') # pure generics
-T = TypeVar('T') # pure generics
+# pure generics
+S = TypeVar('S')
+T = TypeVar('T')
 
 import numpy as np
 import numpy.typing as npt
-from numbers import Number, Real
+from numbers import Number#, Real
 
 
 # Numeric typehints
@@ -30,6 +31,9 @@ BoolNP = TypeVar('BoolNP', bound=np.dtype[np.bool_])
 Shape = tuple
 DType = TypeVar('DType', bound=np.dtype)
 
+## types accepted by 'order' arg of np.linalg.norm()
+OrderType = Optional[Union[int, Literal['fro'], Literal['nuc']]] 
+
 ## Typehints for indeterminate size of a given array dimension
 M = TypeVar('M', bound=int) 
 N = TypeVar('N', bound=int)
@@ -38,7 +42,7 @@ Dims = TypeVar('Dims', bound=int) # intended to typehint the number of dimension
 DimsPlus = TypeVar('DimsPlus', bound=int) # intended to typehint the number of dimensions +1 (no easy way to do arithmetic to generic types yet)
 
 # Fixed-size vector and array type annotations - consider deprecating, since they're not currently being used anywhere
-## DEV: this type of hard-coding sucks, but is the best we can do with the current Python type system
+## TB DEV: this type of hard-coding sucks, but is the best we can do with the current Python type system
 Vector2  = np.ndarray[Shape[Literal[2]], NumericNP]
 Vector3  = np.ndarray[Shape[Literal[3]], NumericNP]
 Vector4  = np.ndarray[Shape[Literal[4]], NumericNP]

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -6,6 +6,7 @@ __email__ = 'timotej.bernat@colorado.edu'
 from typing import (
     Literal,
     Optional,
+    Sequence,
     TypeVar,
     Union,
 )
@@ -71,8 +72,8 @@ BitVectorN = np.ndarray[Shape[N], BoolNP]
 
 # vector comparison
 def as_n_vector(
-    vectorlike : VectorN | Array1xN | ArrayNx1,
-    dimension : int=3,
+    vectorlike : VectorN | Array1xN | ArrayNx1 | Sequence[NumberLike],
+    dimension : Optional[int]=None,
     dtype : Optional[npt.DTypeLike]=None,
 ) -> VectorN:
     '''
@@ -81,11 +82,13 @@ def as_n_vector(
     
     Enables permissive ingestion of vector-shaped objects
     '''
-    if not isinstance(vectorlike, np.ndarray): # TODO: include support for list/tuple-like WITHOUT including sets, str, etc
-        raise TypeError(f'Vectorlike must be a numpy array, not {type(vectorlike)}')
+    # N.B.: strings and byte-like are TECHNICALLY also Sequences, but not the kind we want here
+    if isinstance(vectorlike, (str, bytes)) \
+        or (not isinstance(vectorlike, (np.ndarray, Sequence))):
+        raise TypeError(f'Vectorlike must be a numpy array of Sequence of Numerics, not {type(vectorlike).__name__}')
     
     vector_column = np.atleast_2d(vectorlike).reshape(-1) # permits transposed and nested vector inputs
-    if vector_column.shape != (dimension,):
+    if (dimension is not None) and (vector_column.shape != (dimension,)):
         raise ValueError(
             f'Expected vector with shape {(dimension,)}, got {vector_column.shape}'
         )
@@ -94,21 +97,3 @@ def as_n_vector(
         vector_column = vector_column.astype(dtype)
         
     return vector_column
-
-def compare_optional_positions(
-    position_1 : Optional[VectorN],
-    position_2 : Optional[VectorN],
-    **kwargs,
-) -> bool:
-    '''Check that two positional values are either 1) both undefined, or 2) both defined and equal'''
-    # DEV: replace with monadic interface down the line ("Maybe" pattern?)
-    if type(position_1) != type(position_2):
-        return False
-    
-    if position_1 is None: # both are None
-        return True
-    elif isinstance(position_1, np.ndarray):
-        return np.allclose(position_1, position_2, **kwargs)
-    else:
-        raise TypeError(f'Expected positions to be either None or numpy.ndarray, got {type(position_1)} and {type(position_2)}')
-    

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -48,10 +48,12 @@ Array2x2 = np.ndarray[Shape[Literal[2], Literal[2]], NumericNP]
 Array3x3 = np.ndarray[Shape[Literal[3], Literal[3]], NumericNP]
 Array4x4 = np.ndarray[Shape[Literal[4], Literal[4]], NumericNP]
 
+ArrayNx1 = np.ndarray[Shape[N, Literal[1]], NumericNP]
 ArrayNx2 = np.ndarray[Shape[N, Literal[2]], NumericNP]
 ArrayNx3 = np.ndarray[Shape[N, Literal[3]], NumericNP]
 ArrayNx4 = np.ndarray[Shape[N, Literal[4]], NumericNP]
 
+Array1xN = np.ndarray[Shape[Literal[1], N], NumericNP]
 Array2xN = np.ndarray[Shape[Literal[2], N], NumericNP]
 Array3xN = np.ndarray[Shape[Literal[3], N], NumericNP]
 Array4xN = np.ndarray[Shape[Literal[4], N], NumericNP]

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -59,6 +59,7 @@ ArrayNxN = np.ndarray[Shape[N, N], NumericNP]
 ArrayNxM = np.ndarray[Shape[N, M], NumericNP]
 ArrayMxN = np.ndarray[Shape[M, N], NumericNP]
 
+TriangulationIndices = np.ndarray[Shape[N, Literal[3]], np.dtype[np.integer]]
 
 # vector comparison
 def as_n_vector(vectorlike : np.ndarray[Shape[N], DType], n : N=3) -> np.ndarray[Shape[N], DType]:

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -21,6 +21,7 @@ from numbers import Number, Real
 NumberLike = Union[np.number, Number, float] # DEV: stupidly, but "float" does not typehint as Number in static type checkers, so have to add it manually
 Numeric = TypeVar('Numeric', bound=Number)
 NumericNP = TypeVar('NumericNP', bound=np.dtype[np.number])
+BoolNP = TypeVar('BoolNP', bound=np.dtype[np.bool])
 
 # RealValued = TypeVar('RealValued', bound=Real)
 # RealValuedNP = TypeVar('RealValuedNP', bound=np.dtype[np.floating])
@@ -60,6 +61,7 @@ ArrayNxM = np.ndarray[Shape[N, M], NumericNP]
 ArrayMxN = np.ndarray[Shape[M, N], NumericNP]
 
 TriangulationIndices = np.ndarray[Shape[N, Literal[3]], np.dtype[np.integer]]
+BitVectorN = np.ndarray[Shape[N], BoolNP]
 
 # vector comparison
 def as_n_vector(vectorlike : np.ndarray[Shape[N], DType], n : N=3) -> np.ndarray[Shape[N], DType]:

--- a/mupt/geometry/coordinates/basis.py
+++ b/mupt/geometry/coordinates/basis.py
@@ -4,27 +4,27 @@ __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
 import numpy as np
-from ..arraytypes import Shape, N, Numeric
+from ..arraytypes import Shape, N, NumericNP
 
 
-def are_linearly_independent(*vectors: np.ndarray[Shape[N, ...], Numeric]) -> bool:
+def are_linearly_independent(*vectors: np.ndarray[Shape[N, ...], NumericNP]) -> bool:
     '''Check if the given set of vectors is linearly independent'''
     # NOTE: numpy will raise Exception (as desired) when vectors passed have incompatible shapes
     return np.linalg.matrix_rank(np.column_stack(vectors)) == len(vectors)
 
-def is_diagonal(matrix : np.ndarray[Shape[N, N], Numeric]) -> bool: # TODO: generalize to work for other diagonals
+def is_diagonal(matrix : np.ndarray[Shape[N, N], NumericNP]) -> bool: # TODO: generalize to work for other diagonals
     '''Determine whether a matrix is digonal, i.e. has no nonzero elements off of the main diagonal'''
     return np.allclose(matrix - np.diag(np.diagonal(matrix)), 0.0)
 
-def is_rowspace_mutually_orthogonal(matrix : np.ndarray[Shape[N, N], Numeric]) -> bool:
+def is_rowspace_mutually_orthogonal(matrix : np.ndarray[Shape[N, N], NumericNP]) -> bool:
     '''Check whether all vectors in the row space basis of a matrix are mutually orthogonal'''
     return is_diagonal(matrix @ matrix.T) # note CAREFULLY the order; P_ij = dot(row(i), row(j)) this way
 
-def is_columnspace_mutually_orthogonal(matrix : np.ndarray[Shape[N, N], Numeric]) -> bool:
+def is_columnspace_mutually_orthogonal(matrix : np.ndarray[Shape[N, N], NumericNP]) -> bool:
     '''Check whether all vectors in the column space basis of a matrix are mutually orthogonal'''
     return is_diagonal(matrix.T @ matrix) # note CAREFULLY the order; P_ij = dot(column(i), column(j)) this way
 
-def is_orthogonal(matrix : np.ndarray[Shape[N, N], Numeric]) -> bool:
+def is_orthogonal(matrix : np.ndarray[Shape[N, N], NumericNP]) -> bool:
     '''
     Determine if a matrix is orthogonal, i.e. its left and right inverses are both its own transpose
     Note that the matrix does not necessarily have to be square in order for it to be orthogonal

--- a/mupt/geometry/coordinates/local.py
+++ b/mupt/geometry/coordinates/local.py
@@ -4,14 +4,14 @@ __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
 import numpy as np
-from ..arraytypes import Shape, N, Dims
+from ..arraytypes import Shape, N, Dims, NumericNP
 
 
-def compute_local_coordinates(positions : np.ndarray[Shape[N, Dims], float]) -> tuple[
-        np.ndarray[Shape[Dims], float],
-        np.ndarray[Shape[Dims, Dims], float],
-        np.ndarray[Shape[Dims], float],
-    ]:
+def compute_local_coordinates(positions : np.ndarray[Shape[N, Dims], NumericNP]) -> tuple[
+    np.ndarray[Shape[Dims], NumericNP],
+    np.ndarray[Shape[Dims, Dims], NumericNP],
+    np.ndarray[Shape[Dims], NumericNP],
+]:
     '''
     Takes a coordinates vector of N D-dimensional points and determines
     the center, axes, and relative lengths of the local principal coordinate systems

--- a/mupt/geometry/lattices.py
+++ b/mupt/geometry/lattices.py
@@ -3,13 +3,13 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Generic, Literal
+from typing import Generic
 from dataclasses import dataclass, field
 from numbers import Real
 
 import numpy as np
 
-from .arraytypes import ndarray, Shape, Numeric
+from .arraytypes import Numeric, Array3x3
 
 
 class Coordinates(Generic[Numeric]):
@@ -28,10 +28,10 @@ class LatticeParameters: # TODO : incorporate unit-awareness
     gamma : float = field(default=np.pi / 2) # make cell orthorhombic by default
     
     @classmethod
-    def from_lattice_vectors(cls, lattice_vectors : ndarray[Shape[3, 3], float]) -> 'LatticeParameters':
+    def from_lattice_vectors(cls, lattice_vectors : Array3x3) -> 'LatticeParameters':
         raise NotImplemented
     
-    def to_lattice_vectors(self) -> ndarray[Shape[3, 3], float]:
+    def to_lattice_vectors(self) -> Array3x3:
         raise NotImplemented
     
 # Coordinate subclasses

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -11,12 +11,12 @@ from .arraytypes import (
     Shape,
     NumericNP,
     VectorN,
-    ArrayNxN,
+    ArrayNxM,
 )
 
 
 def normalize(
-    vector : VectorN | ArrayNxN,
+    vector : VectorN | ArrayNxM,
     order : Optional[Union[int, float, str]]=None,
 ) -> None:
     '''Normalize a vector or array of vectors in-place'''

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -5,15 +5,12 @@ __email__ = 'timotej.bernat@colorado.edu'
 
 from typing import Optional, Union
 import numpy as np
-from numpy.typing import DTypeLike
 
 from .arraytypes import (
     N,
     Shape,
     NumericNP,
     VectorN,
-    Array1xN,
-    ArrayNx1,
     ArrayNxN,
 )
 
@@ -52,25 +49,3 @@ def within_ball(
     if not (isinstance(position_1, np.ndarray) and isinstance(position_2, np.ndarray)):
         raise TypeError(f'Expected position attributes to be numpy.ndarray, got {type(position_1)} and {type(position_2)}')
     return (np.linalg.norm(position_1 - position_2, ord=2, axis=-1) < radius).astype(object) # cast to Python bool
-
-def vector_flexible(
-    vectorlike : VectorN | Array1xN | ArrayNx1,
-    dimension : int=3,
-    dtype : Optional[DTypeLike]=None,
-) -> VectorN:
-    '''
-    Convert row vector, column vector, Nx1 array, or 1xN array into
-    1D column vector with appropriate dimension and data type
-    
-    Enables permissive ingestion of vector-shaped objects
-    '''
-    vector_column = np.atleast_2d(vectorlike).reshape(-1) # permits transposed and nested vector inputs
-    if vector_column.shape != (dimension,):
-        raise ValueError(
-            f'Expected vector with shape {(dimension,)}, got {vector_column.shape}'
-        )
-    
-    if dtype is not None:
-        vector_column = vector_column.astype(dtype)
-        
-    return vector_column

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -5,8 +5,17 @@ __email__ = 'timotej.bernat@colorado.edu'
 
 from typing import Optional, Union
 import numpy as np
+from numpy.typing import DTypeLike
 
-from .arraytypes import Shape, N, NumericNP, VectorN, ArrayNxN
+from .arraytypes import (
+    N,
+    Shape,
+    NumericNP,
+    VectorN,
+    Array1xN,
+    ArrayNx1,
+    ArrayNxN,
+)
 
 
 def normalize(
@@ -43,3 +52,22 @@ def within_ball(
     if not (isinstance(position_1, np.ndarray) and isinstance(position_2, np.ndarray)):
         raise TypeError(f'Expected position attributes to be numpy.ndarray, got {type(position_1)} and {type(position_2)}')
     return (np.linalg.norm(position_1 - position_2, ord=2, axis=-1) < radius).astype(object) # cast to Python bool
+
+def vector_flexible(
+    vectorlike : VectorN | Array1xN | ArrayNx1,
+    dimension : int=3,
+    dtype : Optional[DTypeLike]=None,
+) -> VectorN:
+    '''
+    Convert row vector, column vector, Nx1 array, or 1xN array into
+    1D column vector with appropriate dimension and data type
+    
+    Enables permissive ingestion of vector-shaped objects
+    '''
+    vector_column = np.atleast_2d(vectorlike).reshape(-1) # permits transposed and nested vector inputs
+    assert vector_column.shape == (dimension,)
+    
+    if dtype is not None:
+        vector_column = vector_column.astype(dtype)
+        
+    return vector_column

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -65,7 +65,10 @@ def vector_flexible(
     Enables permissive ingestion of vector-shaped objects
     '''
     vector_column = np.atleast_2d(vectorlike).reshape(-1) # permits transposed and nested vector inputs
-    assert vector_column.shape == (dimension,)
+    if vector_column.shape != (dimension,):
+        raise ValueError(
+            f'Expected vector with shape {(dimension,)}, got {vector_column.shape}'
+        )
     
     if dtype is not None:
         vector_column = vector_column.astype(dtype)

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -8,16 +8,17 @@ import numpy as np
 
 from .arraytypes import (
     N,
-    Shape,
     NumericNP,
+    OrderType,
+    Shape,
     VectorN,
     ArrayNxM,
 )
 
 
 def normalize(
-    vector : VectorN | ArrayNxM,
-    order : Optional[Union[int, float, str]]=None,
+    vector : VectorN | ArrayNxN,
+    order : OrderType=None,
 ) -> None:
     '''Normalize a vector or array of vectors in-place'''
     norms = np.atleast_1d( # ensure shape is broadcastable, even for scalars
@@ -29,20 +30,24 @@ def normalize(
     vector /= norms
 
 def normalized(
-    vector : np.ndarray[Shape[N, ...], NumericNP], # DEV: using generic here to indicate return has same dtype
-    order  : Optional[Union[int, float, str]]=None,
+    # DEV: using generic here to indicate return has same dtype
+    vector : np.ndarray[Shape[N, ...], NumericNP], 
+    order : OrderType=None,
 ) -> np.ndarray[Shape[N, ...], NumericNP]:
-    '''Return a normalized copy of a vector or array of vectors;
-    The array supplied to "vector" is unchanged'''
-    new_vector = np.copy(vector)  # preserve original vector
+    '''
+    Return a normalized copy of a vector or array of vectors;
+    The array supplied to "vector" is unchanged
+    '''
+    new_vector = np.copy(vector)
     normalize(new_vector, order=order)
 
     return new_vector
 
-def within_ball(
-    position_1 : VectorN,
-    position_2 : VectorN,
-    radius : float=1E-6,
+def compare_optional_positions(
+    position_1 : Optional[VectorN],
+    position_2 : Optional[VectorN],
+    radius : float=1E-8,
+    order : OrderType=None,
 ) -> bool:
     '''Check that two vectors are within a certain absolute distance of one another'''
     # TODO: check vector shapes match

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -3,16 +3,16 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Any, Optional, Union
+from typing import Optional, Union
 import numpy as np
 
-from .arraytypes import Shape, N, Numeric
+from .arraytypes import Shape, N, NumericNP, VectorN, ArrayNxN
 
 
 def normalize(
-        vector : np.ndarray[Shape[Any], Numeric],
-        order  : Optional[Union[int, float, str]]=None,
-    ) -> None:
+    vector : VectorN | ArrayNxN,
+    order : Optional[Union[int, float, str]]=None,
+) -> None:
     '''Normalize a vector or array of vectors in-place'''
     norms = np.atleast_1d( # ensure shape is broadcastable, even for scalars
         np.linalg.norm(vector, ord=order, axis=-1, keepdims=True)
@@ -23,9 +23,9 @@ def normalize(
     vector /= norms
 
 def normalized(
-        vector : np.ndarray[Shape[N, ...], Numeric],
-        order  : Optional[Union[int, float, str]]=None,
-    ) -> np.ndarray[Shape[N, ...], Numeric]:
+    vector : np.ndarray[Shape[N, ...], NumericNP], # DEV: using generic here to indicate return has same dtype
+    order  : Optional[Union[int, float, str]]=None,
+) -> np.ndarray[Shape[N, ...], NumericNP]:
     '''Return a normalized copy of a vector or array of vectors;
     The array supplied to "vector" is unchanged'''
     new_vector = np.copy(vector)  # preserve original vector
@@ -34,8 +34,8 @@ def normalized(
     return new_vector
 
 def within_ball(
-    position_1 : np.ndarray[Shape[N], float],
-    position_2 : np.ndarray[Shape[N], float],
+    position_1 : VectorN,
+    position_2 : VectorN,
     radius : float=1E-6,
 ) -> bool:
     '''Check that two vectors are within a certain absolute distance of one another'''

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -3,7 +3,7 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Optional, Union
+from typing import Optional
 import numpy as np
 
 from .arraytypes import (
@@ -17,7 +17,7 @@ from .arraytypes import (
 
 
 def normalize(
-    vector : VectorN | ArrayNxN,
+    vector : VectorN | ArrayNxM,
     order : OrderType=None,
 ) -> None:
     '''Normalize a vector or array of vectors in-place'''
@@ -49,8 +49,28 @@ def compare_optional_positions(
     radius : float=1E-8,
     order : OrderType=None,
 ) -> bool:
-    '''Check that two vectors are within a certain absolute distance of one another'''
-    # TODO: check vector shapes match
-    if not (isinstance(position_1, np.ndarray) and isinstance(position_2, np.ndarray)):
-        raise TypeError(f'Expected position attributes to be numpy.ndarray, got {type(position_1)} and {type(position_2)}')
-    return (np.linalg.norm(position_1 - position_2, ord=2, axis=-1) < radius).astype(object) # cast to Python bool
+    '''
+    Check that two positional values are either:
+    * Both undefined (returns True)
+    * Both defined AND within a set in distance in a given p-norm (returns True if both conditions are met)
+    * One defined and one undefined, in either order (returns False)
+    '''
+    if type(position_1) != type(position_2):
+        return False
+    
+    if position_1 is None: # both are None
+        return True
+    elif isinstance(position_1, np.ndarray):
+        return (
+            np.linalg.norm(
+                position_1 - position_2,
+                ord=order,
+                axis=-1,
+            ) < radius
+        ).astype(object) # cast to Python bool
+    else:
+        raise TypeError(
+            f'Expected positions to be either NoneType or numpy.ndarray: ' \
+            f'got {type(position_1).__name__} and {type(position_2).__name__}'
+        )
+    

--- a/mupt/geometry/shapes.py
+++ b/mupt/geometry/shapes.py
@@ -3,47 +3,151 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Optional, Union
+from typing import runtime_checkable, Literal, Protocol, Optional, Union
+from abc import abstractmethod
 
-from abc import ABC, abstractmethod
 from functools import cached_property
 
 import numpy as np
 from scipy.spatial import ConvexHull, Delaunay
 from scipy.spatial.transform import Rotation, RigidTransform
 
-from .arraytypes import Shape, Numeric, M, N, P
+from .arraytypes import (
+    Shape,
+    NumberLike,
+    NumericNP,
+    N, M, P,
+    Vector3,
+    Array3x3,
+    Array4x4,
+    ArrayNxN,
+    ArrayNx3,
+)
+TriangulationIndices = np.ndarray[Shape[N, Literal[3]], np.dtype[np.integer]] # DEV: might move this elsewhere later
 from .coordinates.basis import is_columnspace_mutually_orthogonal
 from .transforms.rigid.application import RigidlyTransformable
 
 
+@runtime_checkable # TODO: make class which composes transformability and boundedness (not necessarily the same a priori)
+class BoundedShape(Protocol):
+    '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
+    # measures of extent
+    @property
+    @abstractmethod
+    def centroid(self) -> Vector3:
+        '''Coordinate of the geometric center of the body'''
+        ...
+    # COM = CoM = center_of_mass = centroid # aliases for convenience
+    
+    @property
+    @abstractmethod
+    def volume(self) -> NumberLike:
+        '''Cumulative measure within the boundary of the body'''
+        ...
+        
+    @abstractmethod
+    def contains(self, points : Vector3 | ArrayNxN) -> bool: 
+        '''Whether a given coordinate lies within the boundary of the body'''
+        ... 
+
+    @abstractmethod
+    def surface_mesh(self, *args, **kwargs) -> tuple[ArrayNx3, TriangulationIndices]:
+        '''
+        Generate a triangulated mesh of the surface of the shape which can be easily digested and plotted by mpl.plot_trisurf
+        
+        Returns
+        -------
+        mesh_points : Array[[N, 3], Numeric]
+            An Nx3 array of the XYZ positions of each point in the mesh
+        tri_vertices : Array[[T, 3], int]
+            A Tx3 array describing the T triples in the mesh, with each row being the triples of array indices of that triangle
+            For example, a row with [1,3,6] represents the triangle traversed counterclockwise from vertices 1 -> 3 -> 6 -> 1
+        '''
+        ...
+    
+    # @abstractmethod
+    # def support(self, direction : np.ndarray[Shape[3], Numeric]) -> np.ndarray[Shape[3], Numeric]:
+    #     '''Determines the furthest point on the surface of the body in a given direction'''
+    #     ...
+
+class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
+    '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
+    ...
+        
+class Shaped(Protocol):
+    '''Interface for objects which have an associated bounded, tranformable shape'''
+    _shape : Optional[BoundedTransformableShape]
+    
+    @property
+    def has_shape(self) -> bool:
+        '''Whether this Primitive has an associated external shape'''
+        return self._shape is not None
+    
+    @property
+    def shape(self) -> Optional[BoundedTransformableShape]: # TODO: make ShapedPrimitive subtype to avoid all these None checks?
+        '''The external shape of this Primitive'''
+        return self._shape
+    
+    @shape.setter
+    def shape(self, new_shape : Optional[BoundedTransformableShape]) -> None:
+        '''Set the external shape of this Primitive with another BoundedShape'''
+        # Case 1) no shape
+        if new_shape is None:
+            self._shape = None
+            return
+        
+        # Case 2) valid shape, which may need to have transformation history transferred over
+        if not isinstance(new_shape, BoundedTransformableShape):
+            raise TypeError(f'Primitive shape must be BoundedShape instance, not object of type {type(new_shape.__name__)}')
+
+        new_shape_clone = new_shape.copy() # NOTE: make copy to avoid mutating original (per Principle of Least Astonishment)
+        if self._shape is not None:
+            new_shape_clone.cumulative_transformation = self._shape.cumulative_transformation # transfer translation history BEFORE overwriting
+        
+        self._shape = new_shape_clone
+        
+        
+# Concrete BoundedShape implementations
 def ellipsoidal_mesh(
     rx : float,
     ry : Optional[float]=None,
     rz : Optional[float]=None,
-    n_theta : M=100,
-    n_phi : P=100,
-    transformation : Optional[RigidTransform]=None,
-) -> np.ndarray[Shape[M, P, 3], Numeric]:
-    # TODO: flesh out docstring w/ Copilot
+    n_theta : int=30,
+    n_phi : int=30,
+    transformation : RigidTransform=RigidTransform.identity(),
+) -> tuple[ArrayNx3, TriangulationIndices]:
     ''' 
     Generate a mesh of points defining the surface of an ellipsoid 
     (i.e. generalized sphere with 3 independent, arbitrarily sized readii)
     
     Parameters
     ----------
-    n_theta : int, default 100
+    rx : float
+        Radius of the ellipsoid in the x-direction or,
+        if no other radii are provided, radius of the sphere
+    ry : Optional[float], default rx
+        Radius of the ellipsoid in the y-direction
+        If not explicitly provided, takes on the value assigned to rx
+    rz : Optional[float], default rx
+        Radius of the ellipsoid in the z-direction
+        If not explicitly provided, takes on the value assigned to rx
+    n_theta : int, default 30
         Number of points in the azimuthal angle direction
         Equivalent to longitudinal resolution
         
         Theta is taken to be the angle CC from the +x axis in the xy-plane,
         following the mathematics (not physics!) convention
-    n_phi : int, default 100
+    n_phi : int, default 30
         Number of points in the polar angle direction
         Equivalent to latitudinal resolution
         
         Phi is taken to be the angle "downwards" from the +z axis
         following the mathematics (not physics!) convention
+    transformation : RigidTransform, default RigidTransform.identity()
+        An additional rigid transformation (i.e. rotation + translation) 
+        to apply to the ellipsoid from it's defined reference position
+        
+        Defaults to the identity transformation, returning the unmodified mesh points
         
     Returns
     -------
@@ -57,58 +161,25 @@ def ellipsoidal_mesh(
     if rz is None:
         rz = ry
 
-    theta, phi = np.mgrid[
+    angles = theta, phi = np.mgrid[
         0.0:2*np.pi:n_theta*1j,
         0.0:np.pi:n_phi*1j,
     ] # (magnitude of) complex step size is interpreted by numpy as a number of points
+    triangulation = Delaunay(angles.reshape(2, -1).T) # note: .reshape(-1, 2) gives the right shape but NOT the right parity between parametric angles
 
     mesh_points = np.zeros((n_theta, n_phi, 3), dtype=float)
     mesh_points[..., 0] = rx * np.sin(phi) * np.cos(theta)
     mesh_points[..., 1] = ry * np.sin(phi) * np.sin(theta)
     mesh_points[..., 2] = rz * np.cos(phi)
     
-    if transformation is not None:
-        mesh_points = transformation.apply(
-            mesh_points.reshape(-1, 3) # flatten into (n_theta*n_phi)x3 array to allow RigidTransform.apply() to digest it
-        ).reshape(n_theta, n_phi, 3) # ...then repackage into mesh for convenient plotting
+    mesh_points = mesh_points.reshape(-1, 3) # flatten into (n_theta*n_phi)x3 array of XYZ positions
+    mesh_points = transformation.apply(mesh_points) # apply transform
 
-    return mesh_points
+    return mesh_points, triangulation.simplices
 
-class BoundedShape(ABC, RigidlyTransformable): # template for numeric type (some iterations of float in most cases)
-    '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
-    # measures of extent
-    @property
-    @abstractmethod
-    def centroid(self) -> np.ndarray[Shape[3], Numeric]:
-        '''Coordinate of the geometric center of the body'''
-        ...
-    # COM = CoM = center_of_mass = centroid # aliases for convenience
-    
-    @property
-    @abstractmethod
-    def volume(self) -> Numeric:
-        '''Cumulative measure within the boundary of the body'''
-        ...
-        
-    @abstractmethod
-    def contains(self, points : np.ndarray[Union[Shape[3], Shape[N, 3]], Numeric]) -> bool: 
-        '''Whether a given coordinate lies within the boundary of the body'''
-        ... 
-
-    # @abstractmethod
-    # def support(self, direction : np.ndarray[Shape[3], Numeric]) -> np.ndarray[Shape[3], Numeric]:
-    #     '''Determines the furthest point on the surface of the body in a given direction'''
-    #     ...
-
-    # @abstractmethod
-    # def surface_mesh(self, *args, **kwargs) -> np.ndarray[Shape[M, P, 3], Numeric]:
-    #     '''Generate a mesh surface representing the BoundedShape which can be easily digested and plotted by mpl.plot_surface'''
-    #     ...
-        
-# Concrete BoundedShape implementations
-class PointCloud(BoundedShape):
+class PointCloud(BoundedTransformableShape):
     '''A cluster of points in 3D space'''
-    def __init__(self, positions : np.ndarray[Shape[N, 3], Numeric]=None) -> None:
+    def __init__(self, positions : Optional[ArrayNx3]=None) -> None:
         if positions is None:
             positions = np.empty((0, 3), dtype=float)
         self.positions = np.atleast_2d(positions)
@@ -118,8 +189,6 @@ class PointCloud(BoundedShape):
         '''Convex hull of the points contained within'''
         return ConvexHull(self.positions)
 
-    ## TODO: add convex hull surface mesh export
-
     @cached_property
     def triangulation(self) -> Delaunay:
         '''Delauney triangulation into simplicial facets whose vertiecs are the positions within'''
@@ -127,40 +196,38 @@ class PointCloud(BoundedShape):
     
     # fulfilling BoundedShape contracts
     @property
-    def centroid(self) -> np.ndarray[Shape[3], Numeric]:
+    def centroid(self) -> Vector3:
         '''Geometric (i.e. unweighted) center of mass'''
         return self.positions.mean(axis=0)
     
     @property
-    def volume(self) -> Numeric:
+    def volume(self) -> NumberLike:
         '''Volume of the convex hull of the positions in this PointCloud'''
         return self.convex_hull.volume
     
-    def contains(self, points : np.ndarray[Union[Shape[3], Shape[N, 3]]]) -> bool:
+    def contains(self, points : Union[Vector3, ArrayNx3]) -> bool:
         return (self.triangulation.find_simplex(points) != -1).astype(object) # need to cast from numpy bool to Python bool
 
     # fulfilling RigidlyTransformable contracts
     def _copy_untransformed(self) -> 'PointCloud':
         return self.__class__(positions=np.array(self.positions))
 
-    def _rigidly_transform(self, transform : RigidTransform) -> None:
-        self.positions = transform.apply(self.positions)
+    def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        self.positions = transformation.apply(self.positions)
 
     # visualization
-    def __repr__(self):
+    def __repr__(self) -> str: 
         return f'{self.__class__.__name__}(shape={self.positions.shape})'
 
-    # def surface_mesh(self) -> np.ndarray[Shape[M, P, 3], Numeric]:
-    #     # TODO: implement calculating this from ConvexHull
-    #     ...
+    def surface_mesh(self) -> tuple[ArrayNx3, TriangulationIndices]:
+        return self.convex_hull.points, self.convex_hull.simplices
 
-
-class Sphere(BoundedShape): # N.B: doesn't inherit from Ellipsoid to avoid Circle-Ellipse problem (https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem)
+class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid to avoid Circle-Ellipse problem (https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem)
     '''A spherical body with arbitrary radius and center'''
     def __init__(self,
         radius : float=1.0,
-        center : np.ndarray[Shape[3], Numeric]=None,
-    ) -> 'Sphere':
+        center : Optional[Vector3]=None,
+    ) -> None:
         if center is None:
             center = np.zeros(3, dtype=float)
         center_std = np.atleast_2d(center).reshape(-1) # permits transposed and nested vector inputs
@@ -172,14 +239,14 @@ class Sphere(BoundedShape): # N.B: doesn't inherit from Ellipsoid to avoid Circl
     
     # fulfilling BoundedShape contracts
     @property
-    def centroid(self) -> np.ndarray[Shape[3], Numeric]:
+    def centroid(self) -> Vector3:
         return self.center
 
     @property
-    def volume(self) -> Numeric:
+    def volume(self) -> float:
         return 4/3 * np.pi * self.radius**3
     
-    def contains(self, points : np.ndarray[Union[Shape[3], Shape[N, 3]]]) -> bool:
+    def contains(self, points : Vector3 | ArrayNxN) -> bool:
         return (
             np.linalg.norm(
                 np.atleast_2d(points - self.center),
@@ -194,16 +261,14 @@ class Sphere(BoundedShape): # N.B: doesn't inherit from Ellipsoid to avoid Circl
             center=np.array(self.center),
         )
 
-    def _rigidly_transform(self, transform : RigidTransform) -> None:
-        self.center = transform.apply(self.center)
+    def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        self.center = transformation.apply(self.center)
 
     # visualization
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{self.__class__.__name__}(radius={self.radius})'
 
-    def surface_mesh(self, n_theta : int=M, n_phi : P=100) -> np.ndarray[Shape[M, P, 3], Numeric]:
-        # TODO: fill in docstring
-        ''''''
+    def surface_mesh(self, n_theta : int=30, n_phi : int=30) -> tuple[ArrayNx3, TriangulationIndices]:
         return ellipsoidal_mesh(
             rx=self.radius,
             # ry, rz forced to match rx if not passed explicitly
@@ -212,8 +277,7 @@ class Sphere(BoundedShape): # N.B: doesn't inherit from Ellipsoid to avoid Circl
             transformation=self.cumulative_transformation,
         )
     
-    
-class Ellipsoid(BoundedShape):
+class Ellipsoid(BoundedTransformableShape):
     '''
     A generalized spherical body, with potentially asymmetric orthogonal principal axes and arbitrary centroid
     
@@ -222,8 +286,8 @@ class Ellipsoid(BoundedShape):
     '''
     def __init__(
         self,
-        radii : np.ndarray[Shape[3], Numeric]=None,
-        center : np.ndarray[Shape[3], Numeric]=None,
+        radii  : Optional[Vector3]=None,
+        center : Optional[Vector3]=None,
     ) -> None:
         # DEV: extract this vector shape checking into external utility, eventually
         if radii is None:
@@ -244,13 +308,13 @@ class Ellipsoid(BoundedShape):
     def from_components(
         cls,
         # axis lengths
-        radius_x : Numeric=1.0,
-        radius_y : Numeric=1.0,
-        radius_z : Numeric=1.0,
+        radius_x : NumberLike=1.0,
+        radius_y : NumberLike=1.0,
+        radius_z : NumberLike=1.0,
+        center_x : NumberLike=0.0,
+        center_y : NumberLike=0.0,
+        center_z : NumberLike=0.0,
         # center coordinate
-        center_x : Numeric=0.0,
-        center_y : Numeric=0.0,
-        center_z : Numeric=0.0,
     ) -> 'Ellipsoid':
         '''Instantiate Ellipsoid from array-wise representations of its radii and center'''
         return cls(
@@ -258,12 +322,12 @@ class Ellipsoid(BoundedShape):
             center=np.array([center_x, center_y, center_z], dtype=float),
         )
 
-    def __repr__(self):
+    def __repr__(self) -> str: 
         return f'{self.__class__.__name__}(radii={self.radii}, center={self.center})'
 
     # Matrix representations of the Ellipsoid
     @staticmethod
-    def is_valid_ellipsoid_matrix(basis : np.ndarray[Shape[4, 4], Numeric]) -> bool:
+    def is_valid_ellipsoid_matrix(basis : Array4x4) -> bool:
         '''Check that an affine matrix could represent an Ellipsoid'''
         assert basis.shape == (4, 4)
         axes, center, projective_part, w = basis[:-1, :-1], basis[:-1, -1], basis[-1, :-1], basis[-1, -1] # TODO: find more elegant way to do this splitting
@@ -274,13 +338,13 @@ class Ellipsoid(BoundedShape):
             and np.isclose(w, 1.0), # ensure homogeneous scale of the center is 1 (i.e. unprojected)
         )
         
-    def scaling_matrix(self, as_affine : bool=True) -> np.ndarray[Union[Shape[3, 3], Shape[4, 4]], Numeric]:
+    def scaling_matrix(self, as_affine : bool=True) -> Union[Array3x3, Array4x4]:
         '''The scaling matrix which defines the radii of the Ellipsoid'''
         if as_affine:
             return np.diag([*self.radii, 1.0])  # add a 1.0 for the homogeneous coordinate
         return np.diag(self.radii)
         
-    def as_affine_matrix(self) -> np.ndarray[Shape[4, 4], Numeric]:
+    def as_affine_matrix(self) -> Array4x4:
         '''
         An affine matrix which represents this Ellipsoid
         
@@ -290,18 +354,18 @@ class Ellipsoid(BoundedShape):
         return self.cumulative_transformation.as_matrix() @ self.scaling_matrix(as_affine=True)
     
     @property
-    def basis(self) -> np.ndarray[Shape[4, 4], Numeric]:
+    def basis(self) -> Array4x4:
         '''The basis matrix of the Ellipsoid - alias for Ellipsoid.as_affine_matrix()'''
         return self.as_affine_matrix()
     
     @property
-    def principal_axes(self) -> np.ndarray[Shape[3, 3], Numeric]:
+    def principal_axes(self) -> Array3x3:
         '''The principal axes of the ellipsoid, represented as a 3x3 matrix
         whose rows are the axis vectors emanating from the Ellipsoid's center'''
         return self.cumulative_transformation.apply( self.scaling_matrix(as_affine=False) )
     axes = principal_axes # alias
 
-    def affine_inverse(self) -> np.ndarray[Shape[4, 4], Numeric]:
+    def affine_inverse(self) -> Array4x4:
         '''
         Transformation which maps this Ellipsoid to the unit sphere centered at the origin
         Inverse of the Ellipsoid's affine basis matrix
@@ -309,7 +373,7 @@ class Ellipsoid(BoundedShape):
         return np.linalg.inv(self.as_affine_matrix) # precompute inverse for later use
     
     @property
-    def inv(self) -> np.ndarray[Shape[4, 4], Numeric]:
+    def inv(self) -> Array4x4:
         '''
         The inverse of the Ellipsoid's affine basis matrix - alias for Ellipsoid.affine_inverse()
         Maps this Ellipsoid to the unit sphere centered at the origin
@@ -323,15 +387,15 @@ class Ellipsoid(BoundedShape):
         
     # fulfilling BoundedShape contracts
     @property
-    def centroid(self) -> np.ndarray[Shape[3], Numeric]:
+    def centroid(self) -> Vector3:
         return self.center
     
     @property
-    def volume(self) -> Numeric:
+    def volume(self) -> NumberLike:
         # return 4/3 * np.pi * np.linalg.det(self.matrix)
         return 4/3 * np.pi * np.prod(self.radii) # DEVNOTE: determination of rotation is always 1, so we may as well skip it and the whole determinant calculation
 
-    def contains(self, points : np.ndarray[Union[Shape[3], Shape[N, 3]]]) -> bool:
+    def contains(self, points : Vector3 | ArrayNxN) -> bool:
         return ( 
             np.linalg.norm( # NOTE: not applying self.inverse to points because the Ellipsoid basis matrix is not, in general, a rigid transformation
                 np.atleast_2d(self.resetting_transformation.apply(points) / self.radii), # reduce containment check to comparison with auxiliary unit sphere
@@ -346,23 +410,23 @@ class Ellipsoid(BoundedShape):
             center=np.array(self.center),
         )
 
-    def _rigidly_transform(self, transform : RigidTransform) -> None:
-        self.center = transform.apply(self.center)
+    def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        self.center = transformation.apply(self.center)
     
     # visualization   
-    def surface_mesh(self, n_theta : int=M, n_phi : P=100) -> np.ndarray[Shape[M, P, 3], Numeric]:
+    def surface_mesh(self, n_theta : int=30, n_phi : int=30) -> tuple[ArrayNx3, TriangulationIndices]:
         '''
         Generate a mesh of points on the surface of this Ellipsoid
         
         Parameters
         ----------
-        n_theta : int, default 100
+        n_theta : int, default 30
             Number of points in the azimuthal angle direction
             Equivalent to longitudinal resolution
             
             Theta is taken to be the angle CC from the +x axis in the xy-plane,
             following the mathematics (not physics!) convention
-        n_phi : int, default 100
+        n_phi : int, default 30
             Number of points in the polar angle direction
             Equivalent to latitudinal resolution
             
@@ -383,3 +447,6 @@ class Ellipsoid(BoundedShape):
             transformation=self.cumulative_transformation,
         )
     
+# class Cylinder(BoundedTransformableShape):
+    # '''A cylindrical body with arbitrary radius, height, and center'''
+    # ...

--- a/mupt/geometry/shapes/__init__.py
+++ b/mupt/geometry/shapes/__init__.py
@@ -1,8 +1,5 @@
 '''For representing spatial information about bounded and rigid bodies'''
 
-__author__ = 'Timotej Bernat'
-__email__ = 'timotej.bernat@colorado.edu'
-
 from .shapes import BoundedShape, BoundedTransformableShape, Shaped
 from .pointcloud import PointCloud
 from .ellipsoid import Sphere, Ellipsoid

--- a/mupt/geometry/shapes/__init__.py
+++ b/mupt/geometry/shapes/__init__.py
@@ -7,3 +7,4 @@ from .shapes import BoundedShape, BoundedTransformableShape, Shaped
 from .pointcloud import PointCloud
 from .ellipsoid import Sphere, Ellipsoid
 from .cylinder import Rod, Cylinder
+from .visualize import visualize_shape

--- a/mupt/geometry/shapes/__init__.py
+++ b/mupt/geometry/shapes/__init__.py
@@ -1,0 +1,9 @@
+'''For representing spatial information about bounded and rigid bodies'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+from .shapes import BoundedShape, BoundedTransformableShape, Shaped
+from .pointcloud import PointCloud
+from .ellipsoid import Sphere, Ellipsoid
+from .cylinder import Rod, Cylinder

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -260,6 +260,11 @@ class Cylinder(BoundedTransformableShape):
 
         return (within_axis & within_radius).astype(object)
 
+    def congruent_to(self, other : 'Cylinder') -> bool:
+        return (self.radius == other.radius) \
+            and (self.length == other.length) \
+            and np.allclose(self.center, other.center)
+
     def scale(self, scaling_factor : float) -> None:
         self.radius *= scaling_factor
         self.length *= scaling_factor

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -202,8 +202,7 @@ class Cylinder(BoundedTransformableShape):
     
     def contains(self, points : Vector3 | ArrayNx3) -> BitVectorN:
         points_centered = np.atleast_2d(points - self.center)
-         # double-transpose needed to get broadcast for multiplication right
-        points_axial = (np.dot(points_centered, self.axis_normal) * points_centered.T).T
+        points_axial = np.outer(np.dot(points_centered, self.axis_normal), self.axis_normal)
         points_radial = points_centered - points_axial
 
         within_axis = np.linalg.norm(points_radial, axis=1) <= (self.length / 2)
@@ -225,6 +224,7 @@ class Cylinder(BoundedTransformableShape):
         )
 
     def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        # TODO: triage why rigid transforms seem to scale normal vector 
         self.axis_normal = transformation.apply(self.axis_normal)
         self.center = transformation.apply(self.center)
 

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -6,6 +6,7 @@ __email__ = 'timotej.bernat@colorado.edu'
 from typing import Optional
 
 import numpy as np
+from scipy.spatial import Delaunay
 from scipy.spatial.transform import RigidTransform
 
 from .shapes import BoundedTransformableShape
@@ -17,6 +18,66 @@ from ..arraytypes import (
     BitVectorN,
 )
 from ..measure import normalized
+from ..transforms.rigid.rotations import alignment_rotation
+
+
+def cylindrical_mesh(
+    radius : float,
+    length : float,
+    n_theta : int=30,
+    n_z : int=5,
+    direction : Optional[Vector3]=None,
+    transformation : RigidTransform=RigidTransform.identity(),
+) -> tuple[ArrayNx3, TriangulationIndices]:
+    '''
+    Generate a mesh of points defining the surface of a cylinder,
+    including the walls and both faces.
+
+    Without an applied transformation, will be centered at the origin
+    with both faces a distance L/2 and -L/2, respectively, relative to
+    the provided normal direction (Default z-axis)
+    
+    Parameters
+    ----------
+    ...
+
+    Returns
+    -------
+    ...
+    '''
+    # compute positions of mesh points
+    params = zs, theta = np.mgrid[
+        -length/2:length/2:n_z*1j,
+        0.0:2*np.pi:(n_theta+1)*1j  # need +1 to get right number of polygon sides (since last is coincident with first)
+    ]
+    xs = radius * np.cos(theta)
+    ys = radius * np.sin(theta)
+
+    mesh_points = np.dstack([xs, ys, zs]).reshape(-1, 3)
+    mesh_points = np.concatenate([-cyl.axis[None, :], mesh_points, cyl.axis[None, :]]) # face midpoints are adjacent to runs of their neighbor points
+    mesh_points = transformation.apply(mesh_points)
+    n_points = len(mesh_points)
+
+    # triangulate mesh points
+    ## bottom face
+    triangles_face_bottom = np.zeros((n_theta, 3), dtype=int)
+    face_bottom_edge_idxs = np.arange(1, n_theta + 1)
+    triangles_face_bottom[:, 0] = 0
+    triangles_face_bottom[:, 1] = face_bottom_edge_idxs
+    triangles_face_bottom[:, 2] = np.roll(face_bottom_edge_idxs, -1)
+
+    ## top face
+    triangles_face_top = np.zeros((n_theta, 3), dtype=int)
+    face_top_edge_idxs = np.arange(n_points - n_theta - 1, n_points - 1)
+    triangles_face_top[:, 0] = n_points - 1
+    triangles_face_top[:, 1] = face_top_edge_idxs
+    triangles_face_top[:, 2] = np.roll(face_top_edge_idxs, -1)
+
+    ## walls
+    triangles_wall = Delaunay(params.reshape(2, -1).T).simplices + 1 # offset accounts for base point prepended to mesh positions
+    triangles = np.concatenate([triangles_face_bottom, triangles_wall, triangles_face_top])
+
+    return mesh_points, triangles
 
 
 class Cylinder(BoundedTransformableShape):
@@ -106,25 +167,13 @@ class Cylinder(BoundedTransformableShape):
         self.axis_normal = transformation.apply(self.axis_normal)
 
     def surface_mesh(self, n_theta : int=30, n_z : int=5) -> tuple[ArrayNx3, TriangulationIndices]:
-        # # calculate cylinder wall coordinates
-        # r, theta = np.mgrid[0.0:R:n_r*1j, 0.0:2*np.pi:n_theta*1j]
-        # x_cyl = R * np.cos(theta) # fix radius for walls
-        # y_cyl = R * np.sin(theta) # fix radius for walls
-        # z, _ = np.mgrid[-L/2:L/2:n_r*1j, 0.0:2*np.pi:n_theta*1j]
-
-        # # calculate face coordinates
-        # x_face = r * np.cos(theta) # vary radius and fix Z for caps
-        # y_face = r * np.sin(theta) # vary radius and fix Z for caps
-        # z_face1 = np.full((n_r, n_theta), fill_value=-L/2)
-        # z_face2 = np.full((n_r, n_theta), fill_value=L/2)
-
-        # # stack XYZ coordinates together
-        # cyl_pos_ref   = np.dstack([x_cyl, y_cyl, z])
-        # face1_pos_ref = np.dstack([x_face, y_face, z_face1])
-        # face2_pos_ref = np.dstack([x_face, y_face, z_face2])
-
-        # apply transform to position in space
-        ## TODO: triangulate + append face midpoints to triangulation
-        ...
+        return cylindrical_mesh(
+            self.radius,
+            self.length,
+            n_theta=n_theta,
+            n_z=n_z,
+            direction=self.axis_normal,
+            transformation=self.cumulative_transformation,
+        )
     
 Rod = Cylinder # alias for convenience

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -216,7 +216,7 @@ class Cylinder(BoundedTransformableShape):
 
     @property
     def L(self) -> float:
-        '''Alias for self.radius'''
+        '''Alias for self.length'''
         return self.length
 
     @property

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -18,7 +18,7 @@ from ..arraytypes import (
     TriangulationIndices,
     BitVectorN,
 )
-from ..measure import normalized
+from ..measure import normalized, vector_flexible
 from ..transforms.rigid.rotations import alignment_rotation
 
 
@@ -146,8 +146,7 @@ class Cylinder(BoundedTransformableShape):
         '''
         if center is None:
             center = np.zeros(3, dtype=float)
-        center_std = np.atleast_2d(center).reshape(-1) # permits transposed and nested vector inputs
-        assert center_std.shape == (3,)
+        center = vector_flexible(center, dimension=3, dtype=float)
 
         half_length : float = length / 2
         if axial_direction is None:

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -254,8 +254,8 @@ class Cylinder(BoundedTransformableShape):
         points_axial = np.outer(np.dot(points_centered, self.axis_normal), self.axis_normal)
         points_radial = points_centered - points_axial
 
-        within_axis = np.linalg.norm(points_radial, axis=1) <= (self.length / 2)
-        within_radius = np.linalg.norm(points_axial, axis=1) <= self.radius
+        within_axis = np.linalg.norm(points_axial, axis=1) <= (self.length / 2)
+        within_radius = np.linalg.norm(points_radial, axis=1) <= self.radius
 
         return (within_axis & within_radius).astype(object)
 
@@ -280,8 +280,7 @@ class Cylinder(BoundedTransformableShape):
     def _rigidly_transform(self, transformation : RigidTransform) -> None:
         self.center = transformation.apply(self.center)
         self.face_center_top = transformation.apply(self.face_center_top)
-        self.face_center_bottom = transformation.apply(self.face_center_top)
-        print(np.linalg.norm(self.axis_normal))
+        self.face_center_bottom = transformation.apply(self.face_center_bottom)
 
     def surface_mesh(self, n_theta : int=30, n_z : int=5) -> tuple[ArrayNx3, TriangulationIndices]:
         return cylindrical_mesh(

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -9,7 +9,13 @@ import numpy as np
 from scipy.spatial.transform import RigidTransform
 
 from .shapes import BoundedTransformableShape
-from ..arraytypes import NumberLike, Vector3, ArrayNx3, TriangulationIndices
+from ..arraytypes import (
+    NumberLike,
+    Vector3,
+    ArrayNx3,
+    TriangulationIndices,
+    BitVectorN,
+)
 from ..measure import normalized
 
 
@@ -72,7 +78,7 @@ class Cylinder(BoundedTransformableShape):
     def volume(self) -> NumberLike:
         return np.pi * self.radius**2 * self.length
     
-    def contains(self, points : Vector3 | ArrayNx3) -> bool:
+    def contains(self, points : Vector3 | ArrayNx3) -> BitVectorN:
         points_centered = np.atleast_2d(points - self.center)
          # double-transpose needed to get broadcast for multiplication right
         points_axial = (np.dot(points_centered, self.axis_normal) * points_centered.T).T
@@ -100,8 +106,6 @@ class Cylinder(BoundedTransformableShape):
         self.axis_normal = transformation.apply(self.axis_normal)
 
     def surface_mesh(self, n_theta : int=30, n_z : int=5) -> tuple[ArrayNx3, TriangulationIndices]:
-        n_r, n_theta = 100, 200
-
         # # calculate cylinder wall coordinates
         # r, theta = np.mgrid[0.0:R:n_r*1j, 0.0:2*np.pi:n_theta*1j]
         # x_cyl = R * np.cos(theta) # fix radius for walls
@@ -121,5 +125,6 @@ class Cylinder(BoundedTransformableShape):
 
         # apply transform to position in space
         ## TODO: triangulate + append face midpoints to triangulation
+        ...
     
 Rod = Cylinder # alias for convenience

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -3,7 +3,7 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Optional
+from typing import Literal, Optional
 
 import numpy as np
 from scipy.spatial import Delaunay
@@ -11,6 +11,7 @@ from scipy.spatial.transform import Rotation, RigidTransform
 
 from .shapes import BoundedTransformableShape
 from ..arraytypes import (
+    Shape,
     NumberLike,
     Vector3,
     ArrayNx3,
@@ -77,13 +78,14 @@ def cylindrical_mesh(
         Array of the triples of indices defining triangular faces in the mesh 
     '''
     # compute positions of mesh points
+    half_length : float = length / 2
     params = zs, theta = np.mgrid[
-        -length/2:length/2:n_z*1j,
+        -half_length:half_length:n_z*1j,
         0.0:2*np.pi:(n_theta+1)*1j  # need +1 to get right number of polygon sides (since last is coincident with first)
     ]
     xs = radius * np.cos(theta)
     ys = radius * np.sin(theta)
-    axis = length/2 * Z_UNIT
+    axis = half_length * Z_UNIT
 
     mesh_points = np.dstack([xs, ys, zs]).reshape(-1, 3)
     mesh_points = np.concatenate([
@@ -125,26 +127,45 @@ class Cylinder(BoundedTransformableShape):
         center : Optional[Vector3]=None,
         axial_direction : Optional[Vector3]=None,
     ) -> None:
+        '''
+        Parameters
+        ----------
+        radius : float, default 1.0
+            The radius of the Cylinder, orthogonal to its central axis
+        length : float, default 2.0
+            The distance between the two parallel faces of the cylinder
+        center : Optional[Vector3], default [0., 0., 0.]
+            The absolute position of the geometric center of the cylinder
+            If not explicitly provided, or provided as NoneType, will default to the origin, i.e. [0., 0., 0.]
+        axial_direction : Optional[Vector3], default [0., 0., 1.]
+            The direction from the center in which the leading ("top") face of the cylinder lies
+            The length of this vector is inconsequential, and will be normalized to `length / 2`
+            i.e. each face lies half of the Cylinder's length away from its center
+            
+            If not explicitly provided, or provided as NoneType, will default to the +z axis, i.e. [0., 0., 1.]
+        '''
         if center is None:
             center = np.zeros(3, dtype=float)
         center_std = np.atleast_2d(center).reshape(-1) # permits transposed and nested vector inputs
         assert center_std.shape == (3,)
 
+        half_length : float = length / 2
         if axial_direction is None:
-            axis_normal = Z_UNIT # default to pointing in z-direction
+            axis_vector = half_length * Z_UNIT # default to pointing in z-direction
             axial_rotation = Rotation.identity()
         else:
             axis_normal = normalized(axial_direction.astype(float))
             axial_rotation = alignment_rotation(Z_UNIT, axis_normal)
+            axis_vector = half_length * axis_normal
 
-        # DEV: opted to have the normal stored internally for 3 reasons:
-        # 1) avoids need to rescale when scaling (accounted for by ".axis" property) 
-        # 2) decreases likelihood of numerical instability when applying rigid transformations
-        # 3) avoids needing to renormalize each time the axis is transformed
         self.radius = radius
         self.length = length
-        self.axis_normal = axis_normal 
         self.center = center
+        # DEV TB: storing absolute positions, rather than relative axis vector,
+        # to ensure cylinder changes as expected under rigid transformations
+        # Axis vector is calculated as difference in-site
+        self.face_center_top = center + axis_vector
+        self.face_center_bottom = center - axis_vector
         self.cumulative_transformation *= RigidTransform.from_components(
             translation=center,
             rotation=axial_rotation,
@@ -158,12 +179,29 @@ class Cylinder(BoundedTransformableShape):
         center : Optional[Vector3]=None,
     ) -> 'Cylinder':
         '''
-        Initialize Cylinder from axial vector (whose length is
-        half the length of the cylinder), centroid, and radius
+        Initialize Cylinder from a radius, axial vector, and centroid
+        
+        Parameters
+        ----------
+        radius : float
+            The radius of the Cylinder, orthogonal to its central axis
+        axial_vector : Vector3
+            A vector whose direction is parallel to the center-to-face direction of the Cylinder
+            and whose length is half of the intended length of the Cylinder
+            
+            E.g. axis_vector=np.array([0., 1., 0.,]) yields a Cylinder of length 2 parallel to the y-axis
+        center : Optional[Vector3], default [0., 0., 0.]
+            The absolute position of the geometric center of the Cylinder
+            If not explicitly provided, or provided as NoneType, will default to the origin, i.e. [0., 0., 0.]
+        
+        Returns
+        -------
+        cylinder : Cylinder
+            A cylinder instance pointing in the desired direction
         '''
         return cls(
             radius=radius,
-            length=np.linalg.norm(axis_vector),
+            length=2*np.linalg.norm(axis_vector),
             center=center,
             axial_direction=axis_vector,
         )
@@ -183,13 +221,25 @@ class Cylinder(BoundedTransformableShape):
 
     @property
     def axis(self) -> Vector3:
-        '''Th vector spanning from the centroid to the center of the leading face'''
-        return (self.length / 2) * self.axis_normal
+        '''
+        The vector spanning from the centroid to the center of the leading face
+        Has length equal to half the length of the Cylinder
+        '''
+        return self.face_center_top - self.center
+    axis_vector = axis
     
     @property
-    def face_centers(self) -> tuple[Vector3, Vector3]:
+    def axis_normal(self) -> Vector3:
+        '''Unit vector in the direction from the centroid to the center of the leading face'''
+        return normalized(self.axis)
+    
+    @property
+    def face_centers(self) -> np.ndarray[
+        Shape[Literal[3], Literal[2]],
+        np.dtype[np.floating],
+    ]:
         '''The absolute positions of the midpoints of the leading and tailing faces on the cylinder'''
-        return (self.center + self.axis, self.center - self.axis)
+        return np.vstack((self.face_center_top, self.face_center_bottom))
 
     # fulfilling BoundedShape contracts
     @property
@@ -224,9 +274,10 @@ class Cylinder(BoundedTransformableShape):
         )
 
     def _rigidly_transform(self, transformation : RigidTransform) -> None:
-        # TODO: triage why rigid transforms seem to scale normal vector 
-        self.axis_normal = transformation.apply(self.axis_normal)
         self.center = transformation.apply(self.center)
+        self.face_center_top = transformation.apply(self.face_center_top)
+        self.face_center_bottom = transformation.apply(self.face_center_top)
+        print(np.linalg.norm(self.axis_normal))
 
     def surface_mesh(self, n_theta : int=30, n_z : int=5) -> tuple[ArrayNx3, TriangulationIndices]:
         return cylindrical_mesh(

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -3,11 +3,113 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
+from typing import Optional
+
+import numpy as np
+from scipy.spatial.transform import RigidTransform
+
 from .shapes import BoundedTransformableShape
+from ..arraytypes import NumberLike, Vector3, ArrayNx3, TriangulationIndices
+from ..measure import normalized
 
 
 class Cylinder(BoundedTransformableShape):
     '''A cylindrical body with arbitrary radius, height, and center'''
-    ... # DEV: fill this in
+    def __init__(
+        self,
+        radius : float=1.0,
+        length : float=2.0,
+        center : Optional[Vector3]=None,
+        axial_direction : Optional[Vector3]=None,
+    ) -> None:
+        if center is None:
+            center = np.zeros(3, dtype=float)
+        center_std = np.atleast_2d(center).reshape(-1) # permits transposed and nested vector inputs
+        assert center_std.shape == (3,)
+
+        if axial_direction is None:
+            axial_direction = np.array([0., 0., 1.]) # default to pointing in z-direction
+
+        self.radius = radius
+        self.length = length
+        # DEV: opted to have the normal stored internally for 3 reasons:
+        # 1) avoids need to rescale when scaling (accounted for by ".axis" property) 
+        # 2) decreases likelihood of numerical instability when applying rigid transformations
+        # 3) avoids needing to renormalize each time the axis is transformed
+        self.axis_normal = normalized(axial_direction) 
+        self.center = center
+        self.cumulative_transformation *= RigidTransform.from_translation(center)
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(radius={self.radius}, length={self.length})'
+    
+    @property
+    def axis(self) -> Vector3:
+        '''Th vector spanning from the centroid to the center of the leading face'''
+        return (self.length / 2) * self.axis_normal
+    
+    @property
+    def face_centers(self) -> tuple[Vector3, Vector3]:
+        '''The absolute positions of the midpoints of the leading and tailing faces on the cylinder'''
+        return (self.center + self.axis, self.center - self.axis)
+
+    # fulfilling BoundedShape contracts
+    @property
+    def centroid(self) -> Vector3:
+        return self.center
+    
+    @property
+    def volume(self) -> NumberLike:
+        return np.pi * self.radius**2 * self.length
+    
+    def contains(self, points : Vector3 | ArrayNx3) -> bool:
+        points_centered = np.atleast_2d(points - self.center)
+         # double-transpose needed to get broadcast for multiplication right
+        points_axial = (np.dot(points_centered, self.axis_normal) * points_centered.T).T
+        points_radial = points_centered - points_axial
+
+        within_axis = np.linalg.norm(points_radial, axis=1) <= (self.length / 2)
+        within_radius = np.linalg.norm(points_axial, axis=1) <= self.radius
+
+        return (within_axis & within_radius).astype(object)
+
+    def scale(self, scaling_factor : float) -> None:
+        self.radius *= scaling_factor
+        self.length *= scaling_factor
+
+    # fulfilling RigidlyTransformable contracts
+    def _copy_untransformed(self) -> 'Cylinder':
+        return self.__class__(
+            radius=self.radius,
+            length=self.length,
+            center=np.array(self.center),
+            axial_direction=np.array(self.axis_normal),
+        )
+
+    def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        self.axis_normal = transformation.apply(self.axis_normal)
+
+    def surface_mesh(self, n_theta : int=30, n_z : int=5) -> tuple[ArrayNx3, TriangulationIndices]:
+        n_r, n_theta = 100, 200
+
+        # # calculate cylinder wall coordinates
+        # r, theta = np.mgrid[0.0:R:n_r*1j, 0.0:2*np.pi:n_theta*1j]
+        # x_cyl = R * np.cos(theta) # fix radius for walls
+        # y_cyl = R * np.sin(theta) # fix radius for walls
+        # z, _ = np.mgrid[-L/2:L/2:n_r*1j, 0.0:2*np.pi:n_theta*1j]
+
+        # # calculate face coordinates
+        # x_face = r * np.cos(theta) # vary radius and fix Z for caps
+        # y_face = r * np.sin(theta) # vary radius and fix Z for caps
+        # z_face1 = np.full((n_r, n_theta), fill_value=-L/2)
+        # z_face2 = np.full((n_r, n_theta), fill_value=L/2)
+
+        # # stack XYZ coordinates together
+        # cyl_pos_ref   = np.dstack([x_cyl, y_cyl, z])
+        # face1_pos_ref = np.dstack([x_face, y_face, z_face1])
+        # face2_pos_ref = np.dstack([x_face, y_face, z_face2])
+
+        # apply transform to position in space
+        ## TODO: triangulate + append face midpoints to triangulation
     
 Rod = Cylinder # alias for convenience

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -260,8 +260,8 @@ class Cylinder(BoundedTransformableShape):
         return (within_axis & within_radius).astype(object)
 
     def congruent_to(self, other : 'Cylinder') -> bool:
-        return (self.radius == other.radius) \
-            and (self.length == other.length) \
+        return np.allclose(self.radius, other.radius) \
+            and np.allclose(self.length, other.length) \
             and np.allclose(self.center, other.center)
 
     def scale(self, scaling_factor : float) -> None:

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -11,6 +11,7 @@ from scipy.spatial.transform import Rotation, RigidTransform
 
 from .shapes import BoundedTransformableShape
 from ..arraytypes import (
+    as_n_vector,
     Shape,
     NumberLike,
     Vector3,
@@ -18,7 +19,7 @@ from ..arraytypes import (
     TriangulationIndices,
     BitVectorN,
 )
-from ..measure import normalized, vector_flexible
+from ..measure import normalized
 from ..transforms.rigid.rotations import alignment_rotation
 
 
@@ -146,7 +147,7 @@ class Cylinder(BoundedTransformableShape):
         '''
         if center is None:
             center = np.zeros(3, dtype=float)
-        center = vector_flexible(center, dimension=3, dtype=float)
+        center = as_n_vector(center, dimension=3, dtype=float)
 
         half_length : float = length / 2
         if axial_direction is None:

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -234,7 +234,7 @@ class Cylinder(BoundedTransformableShape):
     
     @property
     def face_centers(self) -> np.ndarray[
-        Shape[Literal[3], Literal[2]],
+        Shape[Literal[2], Literal[3]],
         np.dtype[np.floating],
     ]:
         '''The absolute positions of the midpoints of the leading and tailing faces on the cylinder'''

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -154,8 +154,8 @@ class Cylinder(BoundedTransformableShape):
     def from_radius_and_axis(
         cls,
         radius : float,
-        center : Vector3,
         axis_vector : Vector3,
+        center : Optional[Vector3]=None,
     ) -> 'Cylinder':
         '''
         Initialize Cylinder from axial vector (whose length is

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -1,0 +1,13 @@
+'''For representing cylindrical, rodlike bodies'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+from .shapes import BoundedTransformableShape
+
+
+class Cylinder(BoundedTransformableShape):
+    '''A cylindrical body with arbitrary radius, height, and center'''
+    ... # DEV: fill this in
+    
+Rod = Cylinder # alias for convenience

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -44,6 +44,16 @@ class Cylinder(BoundedTransformableShape):
         return f'{self.__class__.__name__}(radius={self.radius}, length={self.length})'
     
     @property
+    def R(self) -> float:
+        '''Alias for self.radius'''
+        return self.radius
+
+    @property
+    def L(self) -> float:
+        '''Alias for self.radius'''
+        return self.length
+
+    @property
     def axis(self) -> Vector3:
         '''Th vector spanning from the centroid to the center of the leading face'''
         return (self.length / 2) * self.axis_normal

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -163,7 +163,7 @@ class Cylinder(BoundedTransformableShape):
         '''
         return cls(
             radius=radius,
-            length=np.linalg.norm(axis_vector) / 2,
+            length=np.linalg.norm(axis_vector),
             center=center,
             axial_direction=axis_vector,
         )
@@ -226,6 +226,7 @@ class Cylinder(BoundedTransformableShape):
 
     def _rigidly_transform(self, transformation : RigidTransform) -> None:
         self.axis_normal = transformation.apply(self.axis_normal)
+        self.center = transformation.apply(self.center)
 
     def surface_mesh(self, n_theta : int=30, n_z : int=5) -> tuple[ArrayNx3, TriangulationIndices]:
         return cylindrical_mesh(

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import numpy as np
 from scipy.spatial import Delaunay
-from scipy.spatial.transform import RigidTransform
+from scipy.spatial.transform import Rotation, RigidTransform
 
 from .shapes import BoundedTransformableShape
 from ..arraytypes import (
@@ -21,12 +21,14 @@ from ..measure import normalized
 from ..transforms.rigid.rotations import alignment_rotation
 
 
+Z_UNIT = np.array([0., 0., 1.])
+Z_UNIT.setflags(write=False) # make immutable
+
 def cylindrical_mesh(
     radius : float,
     length : float,
     n_theta : int=30,
     n_z : int=5,
-    direction : Optional[Vector3]=None,
     transformation : RigidTransform=RigidTransform.identity(),
 ) -> tuple[ArrayNx3, TriangulationIndices]:
     '''
@@ -39,11 +41,40 @@ def cylindrical_mesh(
     
     Parameters
     ----------
-    ...
+    radius : float
+        The radius of the cylinder
+    length : float
+        The axial ("face-to-face") length of the cylinder
+    n_theta : int, default 30
+        Number of points to sample in the angular direction
+        Will resemble an extruded regular n_theta-gon, e.g. n_theta=4 will be a square prism
+    n_z : int, default 5
+        Number of points to sample along the cylinder walls in the axial direction
+        E.g. n_z=5 will yield a mesh with bands around the bottom
+        face, 1/4 way up, 1/2 way up, 3/4 way up, and the top face
+    transformation : RigidTransform, default RigidTransform.identity()
+        A rigid transformation (e.g. combined rotation + translation) to apply to the cylinder
+        Used to draw a cylinder which has been rotated and/or displaced from the origin
+
+        By default, will apply the identity transformation, resulting in a cylinder
+        parallel to the z-axis with centroid coincident with the origin
+        i.e. with top and bottom faces at z=-L/2 and z=+L/2, respectively
 
     Returns
     -------
-    ...
+    mesh_points : ndarray[[P, 3], float]
+        The points fo the 3D mesh on the surface of the cylinder
+        
+        The first point will be the midpoint of the bottom face, and the
+        n_theta next points will be the band of neighboring points around the bottom face
+
+        Likewise, the last point in the array will be the midpoint of the top face,
+        with the preceding n_theta points being its neighbors around the edge of the top face
+
+        NB: We take "top" here to mean the face in the axial direction,
+        and "bottom" to mean the face in the opposite direction  
+    triangles : ndarray[[T, 3], int]
+        Array of the triples of indices defining triangular faces in the mesh 
     '''
     # compute positions of mesh points
     params = zs, theta = np.mgrid[
@@ -52,10 +83,15 @@ def cylindrical_mesh(
     ]
     xs = radius * np.cos(theta)
     ys = radius * np.sin(theta)
+    axis = length/2 * Z_UNIT
 
     mesh_points = np.dstack([xs, ys, zs]).reshape(-1, 3)
-    mesh_points = np.concatenate([-cyl.axis[None, :], mesh_points, cyl.axis[None, :]]) # face midpoints are adjacent to runs of their neighbor points
-    mesh_points = transformation.apply(mesh_points)
+    mesh_points = np.concatenate([
+        -axis[None, :],
+        mesh_points,
+        axis[None, :]]
+    ) # face midpoints are adjacent to runs of their neighbor points
+    mesh_points = transformation.apply(mesh_points) # axial tilts should be bundled here
     n_points = len(mesh_points)
 
     # triangulate mesh points
@@ -95,17 +131,42 @@ class Cylinder(BoundedTransformableShape):
         assert center_std.shape == (3,)
 
         if axial_direction is None:
-            axial_direction = np.array([0., 0., 1.]) # default to pointing in z-direction
+            axis_normal = Z_UNIT # default to pointing in z-direction
+            axial_rotation = Rotation.identity()
+        else:
+            axis_normal = normalized(axial_direction.astype(float))
+            axial_rotation = alignment_rotation(Z_UNIT, axis_normal)
 
-        self.radius = radius
-        self.length = length
         # DEV: opted to have the normal stored internally for 3 reasons:
         # 1) avoids need to rescale when scaling (accounted for by ".axis" property) 
         # 2) decreases likelihood of numerical instability when applying rigid transformations
         # 3) avoids needing to renormalize each time the axis is transformed
-        self.axis_normal = normalized(axial_direction) 
+        self.radius = radius
+        self.length = length
+        self.axis_normal = axis_normal 
         self.center = center
-        self.cumulative_transformation *= RigidTransform.from_translation(center)
+        self.cumulative_transformation *= RigidTransform.from_components(
+            translation=center,
+            rotation=axial_rotation,
+        )
+
+    @classmethod
+    def from_radius_and_axis(
+        cls,
+        radius : float,
+        center : Vector3,
+        axis_vector : Vector3,
+    ) -> 'Cylinder':
+        '''
+        Initialize Cylinder from axial vector (whose length is
+        half the length of the cylinder), centroid, and radius
+        '''
+        return cls(
+            radius=radius,
+            length=np.linalg.norm(axis_vector) / 2,
+            center=center,
+            axial_direction=axis_vector,
+        )
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(radius={self.radius}, length={self.length})'
@@ -172,7 +233,6 @@ class Cylinder(BoundedTransformableShape):
             self.length,
             n_theta=n_theta,
             n_z=n_z,
-            direction=self.axis_normal,
             transformation=self.cumulative_transformation,
         )
     

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -1,8 +1,5 @@
 '''For representing cylindrical, rodlike bodies'''
 
-__author__ = 'Timotej Bernat'
-__email__ = 'timotej.bernat@colorado.edu'
-
 from typing import Literal, Optional
 
 import numpy as np

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -260,10 +260,13 @@ class Ellipsoid(BoundedTransformableShape):
         '''
         return self.affine_inverse()
 
-    def coincident_with(self, other : 'Ellipsoid') -> bool:
+    def coincident_with(self, other : 'Ellipsoid') -> bool: # TODO: replace with __eq__
         return np.allclose(self.radii, other.radii) \
             and np.allclose(self.center, other.center) \
-            and np.allclose(self.cumulative_transformation.as_matrix(), other.cumulative_transformation.as_matrix())
+            and np.allclose(
+                self.cumulative_transformation.as_matrix(),
+                other.cumulative_transformation.as_matrix(),
+            )
         
     # fulfilling BoundedShape contracts
     @property

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -1,113 +1,27 @@
-'''For encoding rigid bodies in space'''
+'''For representing ellipsoidal shapes, including spheres as a special case'''
 
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import runtime_checkable, Literal, Protocol, Optional, Union
-from abc import abstractmethod
-
-from functools import cached_property
+from typing import Optional
 
 import numpy as np
-from scipy.spatial import ConvexHull, Delaunay
-from scipy.spatial.transform import Rotation, RigidTransform
+from scipy.spatial import Delaunay
+from scipy.spatial.transform import RigidTransform
 
-from .arraytypes import (
-    Shape,
+from .shapes import BoundedTransformableShape
+from ..arraytypes import (
     NumberLike,
-    NumericNP,
-    N, M, P,
     Vector3,
     Array3x3,
     Array4x4,
     ArrayNxN,
     ArrayNx3,
+    TriangulationIndices,
 )
-TriangulationIndices = np.ndarray[Shape[N, Literal[3]], np.dtype[np.integer]] # DEV: might move this elsewhere later
-from .coordinates.basis import is_columnspace_mutually_orthogonal
-from .transforms.rigid.application import RigidlyTransformable
+from ..coordinates.basis import is_columnspace_mutually_orthogonal
 
-
-@runtime_checkable # TODO: make class which composes transformability and boundedness (not necessarily the same a priori)
-class BoundedShape(Protocol):
-    '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
-    # measures of extent
-    @property
-    @abstractmethod
-    def centroid(self) -> Vector3:
-        '''Coordinate of the geometric center of the body'''
-        ...
-    # COM = CoM = center_of_mass = centroid # aliases for convenience
-    
-    @property
-    @abstractmethod
-    def volume(self) -> NumberLike:
-        '''Cumulative measure within the boundary of the body'''
-        ...
         
-    @abstractmethod
-    def contains(self, points : Vector3 | ArrayNxN) -> bool: 
-        '''Whether a given coordinate lies within the boundary of the body'''
-        ... 
-
-    @abstractmethod
-    def surface_mesh(self, *args, **kwargs) -> tuple[ArrayNx3, TriangulationIndices]:
-        '''
-        Generate a triangulated mesh of the surface of the shape which can be easily digested and plotted by mpl.plot_trisurf
-        
-        Returns
-        -------
-        mesh_points : Array[[N, 3], Numeric]
-            An Nx3 array of the XYZ positions of each point in the mesh
-        tri_vertices : Array[[T, 3], int]
-            A Tx3 array describing the T triples in the mesh, with each row being the triples of array indices of that triangle
-            For example, a row with [1,3,6] represents the triangle traversed counterclockwise from vertices 1 -> 3 -> 6 -> 1
-        '''
-        ...
-    
-    # @abstractmethod
-    # def support(self, direction : np.ndarray[Shape[3], Numeric]) -> np.ndarray[Shape[3], Numeric]:
-    #     '''Determines the furthest point on the surface of the body in a given direction'''
-    #     ...
-
-class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
-    '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
-    ...
-        
-class Shaped(Protocol):
-    '''Interface for objects which have an associated bounded, tranformable shape'''
-    _shape : Optional[BoundedTransformableShape]
-    
-    @property
-    def has_shape(self) -> bool:
-        '''Whether this Primitive has an associated external shape'''
-        return self._shape is not None
-    
-    @property
-    def shape(self) -> Optional[BoundedTransformableShape]: # TODO: make ShapedPrimitive subtype to avoid all these None checks?
-        '''The external shape of this Primitive'''
-        return self._shape
-    
-    @shape.setter
-    def shape(self, new_shape : Optional[BoundedTransformableShape]) -> None:
-        '''Set the external shape of this Primitive with another BoundedShape'''
-        # Case 1) no shape
-        if new_shape is None:
-            self._shape = None
-            return
-        
-        # Case 2) valid shape, which may need to have transformation history transferred over
-        if not isinstance(new_shape, BoundedTransformableShape):
-            raise TypeError(f'Primitive shape must be BoundedShape instance, not object of type {type(new_shape.__name__)}')
-
-        new_shape_clone = new_shape.copy() # NOTE: make copy to avoid mutating original (per Principle of Least Astonishment)
-        if self._shape is not None:
-            new_shape_clone.cumulative_transformation = self._shape.cumulative_transformation # transfer translation history BEFORE overwriting
-        
-        self._shape = new_shape_clone
-        
-        
-# Concrete BoundedShape implementations
 def ellipsoidal_mesh(
     rx : float,
     ry : Optional[float]=None,
@@ -176,51 +90,6 @@ def ellipsoidal_mesh(
     mesh_points = transformation.apply(mesh_points) # apply transform
 
     return mesh_points, triangulation.simplices
-
-class PointCloud(BoundedTransformableShape):
-    '''A cluster of points in 3D space'''
-    def __init__(self, positions : Optional[ArrayNx3]=None) -> None:
-        if positions is None:
-            positions = np.empty((0, 3), dtype=float)
-        self.positions = np.atleast_2d(positions)
-
-    @cached_property
-    def convex_hull(self) -> ConvexHull:
-        '''Convex hull of the points contained within'''
-        return ConvexHull(self.positions)
-
-    @cached_property
-    def triangulation(self) -> Delaunay:
-        '''Delauney triangulation into simplicial facets whose vertiecs are the positions within'''
-        return Delaunay(self.positions)
-    
-    # fulfilling BoundedShape contracts
-    @property
-    def centroid(self) -> Vector3:
-        '''Geometric (i.e. unweighted) center of mass'''
-        return self.positions.mean(axis=0)
-    
-    @property
-    def volume(self) -> NumberLike:
-        '''Volume of the convex hull of the positions in this PointCloud'''
-        return self.convex_hull.volume
-    
-    def contains(self, points : Union[Vector3, ArrayNx3]) -> bool:
-        return (self.triangulation.find_simplex(points) != -1).astype(object) # need to cast from numpy bool to Python bool
-
-    # fulfilling RigidlyTransformable contracts
-    def _copy_untransformed(self) -> 'PointCloud':
-        return self.__class__(positions=np.array(self.positions))
-
-    def _rigidly_transform(self, transformation : RigidTransform) -> None:
-        self.positions = transformation.apply(self.positions)
-
-    # visualization
-    def __repr__(self) -> str: 
-        return f'{self.__class__.__name__}(shape={self.positions.shape})'
-
-    def surface_mesh(self) -> tuple[ArrayNx3, TriangulationIndices]:
-        return self.convex_hull.points, self.convex_hull.simplices
 
 class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid to avoid Circle-Ellipse problem (https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem)
     '''A spherical body with arbitrary radius and center'''
@@ -338,7 +207,7 @@ class Ellipsoid(BoundedTransformableShape):
             and np.isclose(w, 1.0), # ensure homogeneous scale of the center is 1 (i.e. unprojected)
         )
         
-    def scaling_matrix(self, as_affine : bool=True) -> Union[Array3x3, Array4x4]:
+    def scaling_matrix(self, as_affine : bool=True) -> Array3x3 | Array4x4:
         '''The scaling matrix which defines the radii of the Ellipsoid'''
         if as_affine:
             return np.diag([*self.radii, 1.0])  # add a 1.0 for the homogeneous coordinate
@@ -446,7 +315,3 @@ class Ellipsoid(BoundedTransformableShape):
             n_phi=n_phi,
             transformation=self.cumulative_transformation,
         )
-    
-# class Cylinder(BoundedTransformableShape):
-    # '''A cylindrical body with arbitrary radius, height, and center'''
-    # ...

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -66,10 +66,12 @@ def ellipsoidal_mesh(
         
     Returns
     -------
-    ellipsoid_mesh : Array[[M, P, 3], float]
-        A mesh of points on the surface of the Ellipsoid
+    mesh_points : ndarray[[MxP, 3], float]
+        The points fo the 3D mesh on the surface of the cylinder
         M is the number of points in the azimuthal direction
         P is the number of points in the polar direction
+    triangles : ndarray[[T, 3], int]
+        Array of the triples of indices defining triangular faces in the mesh 
     '''
     if ry is None:
         ry = rx
@@ -274,45 +276,20 @@ class Ellipsoid(BoundedTransformableShape):
         return 4/3 * np.pi * np.prod(self.radii) # DEVNOTE: determinant of rotation is always 1, so we may as well skip it
 
     def contains(self, points : Vector3 | ArrayNxN) -> BitVectorN:
+        # Reduce containment check to comparison with auxiliary unit sphere
+        # NB: not applying self.inverse to points because the Ellipsoid basis
+        # matrix in general not a rigid transformation because of axial stretching
         return ( 
-            # Reduce containment check to comparison with auxiliary unit sphere
-            # NB: not applying self.inverse to points because the Ellipsoid basis
-            # matrix in general not a rigid transformation because of axial stretching
             np.linalg.norm( 
                 np.atleast_2d(self.resetting_transformation.apply(points) / self.radii), 
                 axis=1,
-            ) =< 1
+            ) <= 1
         ).astype(object) # need to cast from numpy bool to Python bool
     
     def scale(self, scaling_factor : float) -> None:
         self.radii *= scaling_factor
 
     def surface_mesh(self, n_theta : int=30, n_phi : int=30) -> tuple[ArrayNx3, TriangulationIndices]:
-        '''
-        Generate a mesh of points on the surface of this Ellipsoid
-        
-        Parameters
-        ----------
-        n_theta : int, default 30
-            Number of points in the azimuthal angle direction
-            Equivalent to longitudinal resolution
-            
-            Theta is taken to be the angle CC from the +x axis in the xy-plane,
-            following the mathematics (not physics!) convention
-        n_phi : int, default 30
-            Number of points in the polar angle direction
-            Equivalent to latitudinal resolution
-            
-            Phi is taken to be the angle "downwards" from the +z axis
-            following the mathematics (not physics!) convention
-            
-        Returns
-        -------
-        ellipsoid_mesh : Array[[M, P, 3], float]
-            A mesh of points on the surface of the Ellipsoid
-            M is the number of points in the azimuthal direction
-            P is the number of points in the polar direction
-        '''
         return ellipsoidal_mesh(
             *self.radii,
             n_theta=n_theta,

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -15,7 +15,6 @@ from ..arraytypes import (
     Vector3,
     Array3x3,
     Array4x4,
-    ArrayNxN,
     ArrayNx3,
     TriangulationIndices,
     BitVectorN,
@@ -127,7 +126,7 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
     def volume(self) -> float:
         return 4/3 * np.pi * self.radius**3
     
-    def contains(self, points : Vector3 | ArrayNxN) -> BitVectorN:
+    def contains(self, points : Vector3 | ArrayNx3) -> BitVectorN:
         return (
             np.linalg.norm(
                 np.atleast_2d(points - self.center),
@@ -284,7 +283,7 @@ class Ellipsoid(BoundedTransformableShape):
         # return 4/3 * np.pi * np.linalg.det(self.matrix)
         return 4/3 * np.pi * np.prod(self.radii) # DEVNOTE: determinant of rotation is always 1, so we may as well skip it
 
-    def contains(self, points : Vector3 | ArrayNxN) -> BitVectorN:
+    def contains(self, points : Vector3 | ArrayNx3) -> BitVectorN:
         # Reduce containment check to comparison with auxiliary unit sphere
         # NB: not applying self.inverse to points because the Ellipsoid basis
         # matrix in general not a rigid transformation because of axial stretching

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -256,7 +256,7 @@ class Ellipsoid(BoundedTransformableShape):
         Transformation which maps this Ellipsoid to the unit sphere centered at the origin
         Inverse of the Ellipsoid's affine basis matrix
         '''
-        return np.linalg.inv(self.as_affine_matrix) # precompute inverse for later use
+        return np.linalg.inv(self.as_affine_matrix()) # precompute inverse for later use
     
     @property
     def inv(self) -> Array4x4:
@@ -295,7 +295,7 @@ class Ellipsoid(BoundedTransformableShape):
             ) <= 1
         ).astype(object) # need to cast from numpy bool to Python bool
     
-    def congruent_to(self, other : 'Sphere') -> bool:
+    def congruent_to(self, other : 'Ellipsoid') -> bool:
         return np.allclose(self.radii, other.radii) \
             and np.allclose(self.center, other.center)
 

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -134,6 +134,10 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
                 axis=1, # TODO: 
             ) <= self.radius
         ).astype(object)
+
+    def congruent_to(self, other : 'Sphere') -> bool:
+        return (self.radius == other.radius) \
+            and np.allclose(self.center, other.center)
     
     def scale(self, scaling_factor : float) -> None:
         self.radius *= scaling_factor
@@ -289,6 +293,10 @@ class Ellipsoid(BoundedTransformableShape):
             ) <= 1
         ).astype(object) # need to cast from numpy bool to Python bool
     
+    def congruent_to(self, other : 'Sphere') -> bool:
+        return np.allclose(self.radii, other.radii) \
+            and np.allclose(self.center, other.center)
+
     def scale(self, scaling_factor : float) -> None:
         self.radii *= scaling_factor
 

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -18,6 +18,7 @@ from ..arraytypes import (
     ArrayNxN,
     ArrayNx3,
     TriangulationIndices,
+    BitVectorN,
 )
 from ..coordinates.basis import is_columnspace_mutually_orthogonal
 
@@ -124,7 +125,7 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
     def volume(self) -> float:
         return 4/3 * np.pi * self.radius**3
     
-    def contains(self, points : Vector3 | ArrayNxN) -> bool:
+    def contains(self, points : Vector3 | ArrayNxN) -> BitVectorN:
         return (
             np.linalg.norm(
                 np.atleast_2d(points - self.center),
@@ -272,7 +273,7 @@ class Ellipsoid(BoundedTransformableShape):
         # return 4/3 * np.pi * np.linalg.det(self.matrix)
         return 4/3 * np.pi * np.prod(self.radii) # DEVNOTE: determinant of rotation is always 1, so we may as well skip it
 
-    def contains(self, points : Vector3 | ArrayNxN) -> bool:
+    def contains(self, points : Vector3 | ArrayNxN) -> BitVectorN:
         return ( 
             # NOTE: not applying self.inverse to points because the
             # Ellipsoid basis matrix is not, in general, a rigid transformation

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -1,8 +1,5 @@
 '''For representing ellipsoidal shapes, including spheres as a special case'''
 
-__author__ = 'Timotej Bernat'
-__email__ = 'timotej.bernat@colorado.edu'
-
 from typing import Optional
 
 import numpy as np

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -106,6 +106,9 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
         self.center = center
         self.cumulative_transformation *= RigidTransform.from_translation(center)
     
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(radius={self.radius})'
+    
     # fulfilling BoundedShape contracts
     @property
     def centroid(self) -> Vector3:
@@ -122,20 +125,9 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
                 axis=1, # TODO: 
             ) < self.radius  # TODO: decide whether containment should be boundary-inclusive
         ).astype(object)
-
-    # fulfilling RigidlyTransformable contracts
-    def _copy_untransformed(self) -> 'Sphere':
-        return self.__class__(
-            radius=self.radius,
-            center=np.array(self.center),
-        )
-
-    def _rigidly_transform(self, transformation : RigidTransform) -> None:
-        self.center = transformation.apply(self.center)
-
-    # visualization
-    def __repr__(self) -> str:
-        return f'{self.__class__.__name__}(radius={self.radius})'
+    
+    def scale(self, scaling_factor : float) -> None:
+        self.radius *= scaling_factor
 
     def surface_mesh(self, n_theta : int=30, n_phi : int=30) -> tuple[ArrayNx3, TriangulationIndices]:
         return ellipsoidal_mesh(
@@ -145,6 +137,16 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
             n_phi=n_phi,
             transformation=self.cumulative_transformation,
         )
+    
+    # fulfilling RigidlyTransformable contracts
+    def _copy_untransformed(self) -> 'Sphere':
+        return self.__class__(
+            radius=self.radius,
+            center=np.array(self.center),
+        )
+
+    def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        self.center = transformation.apply(self.center)
     
 class Ellipsoid(BoundedTransformableShape):
     '''
@@ -262,27 +264,22 @@ class Ellipsoid(BoundedTransformableShape):
     @property
     def volume(self) -> NumberLike:
         # return 4/3 * np.pi * np.linalg.det(self.matrix)
-        return 4/3 * np.pi * np.prod(self.radii) # DEVNOTE: determination of rotation is always 1, so we may as well skip it and the whole determinant calculation
+        return 4/3 * np.pi * np.prod(self.radii) # DEVNOTE: determinant of rotation is always 1, so we may as well skip it
 
     def contains(self, points : Vector3 | ArrayNxN) -> bool:
         return ( 
-            np.linalg.norm( # NOTE: not applying self.inverse to points because the Ellipsoid basis matrix is not, in general, a rigid transformation
-                np.atleast_2d(self.resetting_transformation.apply(points) / self.radii), # reduce containment check to comparison with auxiliary unit sphere
+            # NOTE: not applying self.inverse to points because the
+            # Ellipsoid basis matrix is not, in general, a rigid transformation
+            np.linalg.norm( 
+                # reduce containment check to comparison with auxiliary unit sphere
+                np.atleast_2d(self.resetting_transformation.apply(points) / self.radii), 
                 axis=1,
             ) < 1 # TODO: decide whether containment should be boundary-inclusive
         ).astype(object) # need to cast from numpy bool to Python bool
-
-    # fulfilling RigidlyTransformable contracts
-    def _copy_untransformed(self) -> 'Ellipsoid':
-        return self.__class__(
-            radii=np.array(self.radii),
-            center=np.array(self.center),
-        )
-
-    def _rigidly_transform(self, transformation : RigidTransform) -> None:
-        self.center = transformation.apply(self.center)
     
-    # visualization   
+    def scale(self, scaling_factor : float) -> None:
+        self.radii *= scaling_factor
+
     def surface_mesh(self, n_theta : int=30, n_phi : int=30) -> tuple[ArrayNx3, TriangulationIndices]:
         '''
         Generate a mesh of points on the surface of this Ellipsoid
@@ -315,3 +312,13 @@ class Ellipsoid(BoundedTransformableShape):
             n_phi=n_phi,
             transformation=self.cumulative_transformation,
         )
+
+    # fulfilling RigidlyTransformable contracts
+    def _copy_untransformed(self) -> 'Ellipsoid':
+        return self.__class__(
+            radii=np.array(self.radii),
+            center=np.array(self.center),
+        )
+
+    def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        self.center = transformation.apply(self.center)

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -11,6 +11,7 @@ from scipy.spatial.transform import RigidTransform
 
 from .shapes import BoundedTransformableShape
 from ..arraytypes import (
+    as_n_vector,
     NumberLike,
     Vector3,
     Array3x3,
@@ -19,7 +20,6 @@ from ..arraytypes import (
     TriangulationIndices,
     BitVectorN,
 )
-from ..measure import vector_flexible
 from ..coordinates.basis import is_columnspace_mutually_orthogonal
 
         
@@ -103,7 +103,7 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
     ) -> None:
         if center is None:
             center = np.zeros(3, dtype=float)
-        center = vector_flexible(center, dimension=3, dtype=float)
+        center = as_n_vector(center, dimension=3, dtype=float)
 
         self.radius = radius
         self.center = center
@@ -175,11 +175,11 @@ class Ellipsoid(BoundedTransformableShape):
         # DEV: extract this vector shape checking into external utility, eventually
         if radii is None:
             radii = np.ones(3, dtype=float)
-        radii = vector_flexible(radii, dimension=3, dtype=float)
+        radii = as_n_vector(radii, dimension=3, dtype=float)
             
         if center is None:
             center = np.zeros(3, dtype=float)
-        center = vector_flexible(center, dimension=3, dtype=float)
+        center = as_n_vector(center, dimension=3, dtype=float)
 
         self.radii = radii
         self.center = center

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -82,7 +82,7 @@ def ellipsoidal_mesh(
     ] # (magnitude of) complex step size is interpreted by numpy as a number of points
     triangulation = Delaunay(angles.reshape(2, -1).T) # note: .reshape(-1, 2) gives the right shape but NOT the right parity between parametric angles
 
-    mesh_points = np.zeros((n_theta, n_phi, 3), dtype=float)
+    mesh_points = np.zeros((n_theta, n_phi, 3), dtype=float) # TODO: rewrite as dstack?
     mesh_points[..., 0] = rx * np.sin(phi) * np.cos(theta)
     mesh_points[..., 1] = ry * np.sin(phi) * np.sin(theta)
     mesh_points[..., 2] = rz * np.cos(phi)
@@ -240,7 +240,7 @@ class Ellipsoid(BoundedTransformableShape):
     def principal_axes(self) -> Array3x3:
         '''The principal axes of the ellipsoid, represented as a 3x3 matrix
         whose rows are the axis vectors emanating from the Ellipsoid's center'''
-        return self.cumulative_transformation.apply( self.scaling_matrix(as_affine=False) )
+        return self.cumulative_transformation.apply(self.scaling_matrix(as_affine=False))
     axes = principal_axes # alias
 
     def affine_inverse(self) -> Array4x4:
@@ -275,13 +275,13 @@ class Ellipsoid(BoundedTransformableShape):
 
     def contains(self, points : Vector3 | ArrayNxN) -> BitVectorN:
         return ( 
-            # NOTE: not applying self.inverse to points because the
-            # Ellipsoid basis matrix is not, in general, a rigid transformation
+            # Reduce containment check to comparison with auxiliary unit sphere
+            # NB: not applying self.inverse to points because the Ellipsoid basis
+            # matrix in general not a rigid transformation because of axial stretching
             np.linalg.norm( 
-                # reduce containment check to comparison with auxiliary unit sphere
                 np.atleast_2d(self.resetting_transformation.apply(points) / self.radii), 
                 axis=1,
-            ) < 1 # TODO: decide whether containment should be boundary-inclusive
+            ) =< 1
         ).astype(object) # need to cast from numpy bool to Python bool
     
     def scale(self, scaling_factor : float) -> None:

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -93,7 +93,8 @@ def ellipsoidal_mesh(
 
 class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid to avoid Circle-Ellipse problem (https://en.wikipedia.org/wiki/Circle%E2%80%93ellipse_problem)
     '''A spherical body with arbitrary radius and center'''
-    def __init__(self,
+    def __init__(
+        self,
         radius : float=1.0,
         center : Optional[Vector3]=None,
     ) -> None:
@@ -109,6 +110,11 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(radius={self.radius})'
     
+    @property
+    def R(self) -> float:
+        '''Alias for self.radius'''
+        return self.radius
+
     # fulfilling BoundedShape contracts
     @property
     def centroid(self) -> Vector3:
@@ -123,7 +129,7 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
             np.linalg.norm(
                 np.atleast_2d(points - self.center),
                 axis=1, # TODO: 
-            ) < self.radius  # TODO: decide whether containment should be boundary-inclusive
+            ) <= self.radius
         ).astype(object)
     
     def scale(self, scaling_factor : float) -> None:

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -136,7 +136,7 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
         ).astype(object)
 
     def congruent_to(self, other : 'Sphere') -> bool:
-        return (self.radius == other.radius) \
+        return np.allclose(self.radius, other.radius) \
             and np.allclose(self.center, other.center)
     
     def scale(self, scaling_factor : float) -> None:

--- a/mupt/geometry/shapes/ellipsoid.py
+++ b/mupt/geometry/shapes/ellipsoid.py
@@ -20,6 +20,7 @@ from ..arraytypes import (
     TriangulationIndices,
     BitVectorN,
 )
+from ..measure import vector_flexible
 from ..coordinates.basis import is_columnspace_mutually_orthogonal
 
         
@@ -103,8 +104,7 @@ class Sphere(BoundedTransformableShape): # N.B: doesn't inherit from Ellipsoid t
     ) -> None:
         if center is None:
             center = np.zeros(3, dtype=float)
-        center_std = np.atleast_2d(center).reshape(-1) # permits transposed and nested vector inputs
-        assert center_std.shape == (3,)
+        center = vector_flexible(center, dimension=3, dtype=float)
 
         self.radius = radius
         self.center = center
@@ -176,13 +176,11 @@ class Ellipsoid(BoundedTransformableShape):
         # DEV: extract this vector shape checking into external utility, eventually
         if radii is None:
             radii = np.ones(3, dtype=float)
-        radii_std = np.atleast_2d(radii).reshape(-1) # permits transposed and nested vector inputs
-        assert radii_std.shape == (3,)
+        radii = vector_flexible(radii, dimension=3, dtype=float)
             
         if center is None:
             center = np.zeros(3, dtype=float)
-        center_std = np.atleast_2d(center).reshape(-1) # permits transposed and nested vector inputs
-        assert center_std.shape == (3,)
+        center = vector_flexible(center, dimension=3, dtype=float)
 
         self.radii = radii
         self.center = center
@@ -214,7 +212,11 @@ class Ellipsoid(BoundedTransformableShape):
     def is_valid_ellipsoid_matrix(basis : Array4x4) -> bool:
         '''Check that an affine matrix could represent an Ellipsoid'''
         assert basis.shape == (4, 4)
-        axes, center, projective_part, w = basis[:-1, :-1], basis[:-1, -1], basis[-1, :-1], basis[-1, -1] # TODO: find more elegant way to do this splitting
+        # TODO: find more elegant way to do this splitting
+        axes = basis[:-1, :-1]
+        center = basis[:-1, -1]
+        projective_part = basis[-1, :-1]
+        w = basis[-1, -1]
         
         return bool(
             is_columnspace_mutually_orthogonal(axes) # ensure principal axes are mutually orthogonal

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -90,6 +90,9 @@ class PointCloud(BoundedTransformableShape):
             self.triangulation.find_simplex(points) != -1
         ).astype(object) # need to cast from numpy bool to Python bool
 
+    def congruent_to(self, other : 'PointCloud') -> bool:
+        return np.allclose(self.positions, other.positions)
+
     def scale(self, scaling_factor : float) -> None:
         self.positions = scaling_factor*self.positions + (1 - scaling_factor)*self.centroid
 

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -1,0 +1,60 @@
+'''For representing clusters of positional coordinate, as one might find in a molecular conformer'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+from typing import Optional
+from functools import cached_property
+
+import numpy as np
+from scipy.spatial.transform import RigidTransform
+from scipy.spatial import ConvexHull, Delaunay
+
+from .shapes import BoundedTransformableShape
+from ..arraytypes import NumberLike, Vector3, ArrayNx3, TriangulationIndices
+
+
+class PointCloud(BoundedTransformableShape):
+    '''A cluster of points in 3D space'''
+    def __init__(self, positions : Optional[ArrayNx3]=None) -> None:
+        if positions is None:
+            positions = np.empty((0, 3), dtype=float)
+        self.positions = np.atleast_2d(positions)
+
+    @cached_property
+    def convex_hull(self) -> ConvexHull:
+        '''Convex hull of the points contained within'''
+        return ConvexHull(self.positions)
+
+    @cached_property
+    def triangulation(self) -> Delaunay:
+        '''Delauney triangulation into simplicial facets whose vertiecs are the positions within'''
+        return Delaunay(self.positions)
+    
+    # fulfilling BoundedShape contracts
+    @property
+    def centroid(self) -> Vector3:
+        '''Geometric (i.e. unweighted) center of mass'''
+        return self.positions.mean(axis=0)
+    
+    @property
+    def volume(self) -> NumberLike:
+        '''Volume of the convex hull of the positions in this PointCloud'''
+        return self.convex_hull.volume
+    
+    def contains(self, points : Vector3 | ArrayNx3) -> bool:
+        return (self.triangulation.find_simplex(points) != -1).astype(object) # need to cast from numpy bool to Python bool
+
+    # fulfilling RigidlyTransformable contracts
+    def _copy_untransformed(self) -> 'PointCloud':
+        return self.__class__(positions=np.array(self.positions))
+
+    def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        self.positions = transformation.apply(self.positions)
+
+    # visualization
+    def __repr__(self) -> str: 
+        return f'{self.__class__.__name__}(shape={self.positions.shape})'
+
+    def surface_mesh(self) -> tuple[ArrayNx3, TriangulationIndices]:
+        return self.convex_hull.points, self.convex_hull.simplices

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -28,7 +28,7 @@ class PointCloud(BoundedTransformableShape):
         return f'{self.__class__.__name__}(shape={self.positions.shape})'
     
     @classmethod
-    def cubic(cls, sidelen : float=1.0, centered : bool=True) -> PointCloud:
+    def cubic(cls, sidelen : float=1.0, centered : bool=True) -> 'PointCloud':
         '''
         Initialize a PointCloud whose point lie on the
         vertices of a cube with the given side lengths

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -21,6 +21,9 @@ class PointCloud(BoundedTransformableShape):
             positions = np.empty((0, 3), dtype=float)
         self.positions = np.atleast_2d(positions)
 
+    def __repr__(self) -> str: 
+        return f'{self.__class__.__name__}(shape={self.positions.shape})'
+    
     @cached_property
     def convex_hull(self) -> ConvexHull:
         '''Convex hull of the points contained within'''
@@ -45,16 +48,15 @@ class PointCloud(BoundedTransformableShape):
     def contains(self, points : Vector3 | ArrayNx3) -> bool:
         return (self.triangulation.find_simplex(points) != -1).astype(object) # need to cast from numpy bool to Python bool
 
+    def scale(self, scaling_factor : float) -> None:
+        self.positions = scaling_factor*(self.positions - self.centroid) + self.centroid
+
+    def surface_mesh(self) -> tuple[ArrayNx3, TriangulationIndices]:
+        return self.convex_hull.points, self.convex_hull.simplices
+    
     # fulfilling RigidlyTransformable contracts
     def _copy_untransformed(self) -> 'PointCloud':
         return self.__class__(positions=np.array(self.positions))
 
     def _rigidly_transform(self, transformation : RigidTransform) -> None:
         self.positions = transformation.apply(self.positions)
-
-    # visualization
-    def __repr__(self) -> str: 
-        return f'{self.__class__.__name__}(shape={self.positions.shape})'
-
-    def surface_mesh(self) -> tuple[ArrayNx3, TriangulationIndices]:
-        return self.convex_hull.points, self.convex_hull.simplices

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -94,7 +94,14 @@ class PointCloud(BoundedTransformableShape):
         self.positions = scaling_factor*self.positions + (1 - scaling_factor)*self.centroid
 
     def surface_mesh(self) -> tuple[ArrayNx3, TriangulationIndices]:
-        return self.convex_hull.points, self.convex_hull.simplices
+        verts = self.convex_hull.vertices  # NB: self.convex_hull.points returns ALL points, even in interior 
+        remap : dict[int, int] = {
+            old_idx : new_idx
+                for new_idx, old_idx in enumerate(verts)
+        }
+        remapped = np.vectorize(lambda x: remap.get(x, x))
+
+        return self.positions[verts], remapped(self.convex_hull.simplices)
     
     # fulfilling RigidlyTransformable contracts
     def _copy_untransformed(self) -> 'PointCloud':

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -1,8 +1,5 @@
 '''For representing clusters of positional coordinate, as one might find in a molecular conformer'''
 
-__author__ = 'Timotej Bernat'
-__email__ = 'timotej.bernat@colorado.edu'
-
 from typing import Iterable, Literal, Optional
 
 from functools import cached_property

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -12,6 +12,7 @@ from scipy.spatial import ConvexHull, Delaunay
 
 from .shapes import BoundedTransformableShape
 from ..arraytypes import NumberLike, Vector3, ArrayNx3, TriangulationIndices
+from ...mutils.copyable import clear_cached_properties
 
 
 class PointCloud(BoundedTransformableShape):
@@ -49,7 +50,7 @@ class PointCloud(BoundedTransformableShape):
         return (self.triangulation.find_simplex(points) != -1).astype(object) # need to cast from numpy bool to Python bool
 
     def scale(self, scaling_factor : float) -> None:
-        self.positions = scaling_factor*(self.positions - self.centroid) + self.centroid
+        self.positions = scaling_factor*self.positions + (1 - scaling_factor)*self.centroid
 
     def surface_mesh(self) -> tuple[ArrayNx3, TriangulationIndices]:
         return self.convex_hull.points, self.convex_hull.simplices
@@ -60,3 +61,4 @@ class PointCloud(BoundedTransformableShape):
 
     def _rigidly_transform(self, transformation : RigidTransform) -> None:
         self.positions = transformation.apply(self.positions)
+        clear_cached_properties(self) # invalidate cached qHull objects to prevent invariant plotting bug

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -3,15 +3,17 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Optional
+from typing import Iterable, Literal, Optional
+
 from functools import cached_property
+from itertools import product as cartesian
 
 import numpy as np
 from scipy.spatial.transform import RigidTransform
 from scipy.spatial import ConvexHull, Delaunay
 
 from .shapes import BoundedTransformableShape
-from ..arraytypes import NumberLike, Vector3, ArrayNx3, TriangulationIndices
+from ..arraytypes import Shape, NumberLike, Vector3, ArrayNx3, TriangulationIndices
 from ...mutils.copyable import clear_cached_properties
 
 
@@ -25,6 +27,36 @@ class PointCloud(BoundedTransformableShape):
     def __repr__(self) -> str: 
         return f'{self.__class__.__name__}(shape={self.positions.shape})'
     
+    @classmethod
+    def cubic(cls, sidelen : float=1.0, centered : bool=True) -> PointCloud:
+        '''
+        Initialize a PointCloud whose point lie on the
+        vertices of a cube with the given side lengths
+        
+        Parameters
+        ----------
+        sidelen : float, default 1.0
+            The sidelen of the embedded cube
+        centered : bool, default True
+            Whether or not to center the vertices about the origin
+            * If True, vertices will lie at the points (±S/2, ±S/2, ±S/2)
+            * If False, the first vertex will lie at (0, 0, 0)
+            and the rest extend by S into the first quadrant
+        
+        Returns
+        -------
+        cubic : PointCloud
+            A PointCloud instance whose 8 vertices 
+            are the vertices of the specified cube
+        
+        '''
+        vertices : Iterable[tuple[int, int, int]] = cartesian(*[(0.0, sidelen) for _ in range(3)])
+        positions : np.ndarray[Shape[Literal[8], Literal[3]], np.floating] = np.array(list(vertices))
+        if centered:
+            positions -= (sidelen / 2)
+
+        return cls(positions)
+
     @cached_property
     def convex_hull(self) -> ConvexHull:
         '''Convex hull of the points contained within'''
@@ -62,3 +94,13 @@ class PointCloud(BoundedTransformableShape):
     def _rigidly_transform(self, transformation : RigidTransform) -> None:
         self.positions = transformation.apply(self.positions)
         clear_cached_properties(self) # invalidate cached qHull objects to prevent invariant plotting bug
+
+    # derived quantities
+    @property
+    def bounding_radius(self) -> float:
+        '''
+        Bounding radius of the point cloud, defined as the 
+        maximum center-of-mass distance scross all points
+        '''
+        return np.linalg.norm(self.positions - self.centroid, axis=1).max()
+    r_bound = bounding_radius

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -34,7 +34,7 @@ class PointCloud(BoundedTransformableShape):
     def __repr__(self) -> str: 
         return f'{self.__class__.__name__}(shape={self.positions.shape})'
     
-    @classmethod
+    @classmethod # TODO: per DS review, would make sense to eventually move this into dedicated Cubic subtype of BoundedTransformableShape
     def cubic(cls, sidelen : float=1.0, centered : bool=True) -> 'PointCloud':
         '''
         Initialize a PointCloud whose point lie on the

--- a/mupt/geometry/shapes/pointcloud.py
+++ b/mupt/geometry/shapes/pointcloud.py
@@ -13,7 +13,14 @@ from scipy.spatial.transform import RigidTransform
 from scipy.spatial import ConvexHull, Delaunay
 
 from .shapes import BoundedTransformableShape
-from ..arraytypes import Shape, NumberLike, Vector3, ArrayNx3, TriangulationIndices
+from ..arraytypes import (
+    Shape,
+    NumberLike,
+    Vector3,
+    ArrayNx3,
+    BitVectorN,
+    TriangulationIndices,
+)
 from ...mutils.copyable import clear_cached_properties
 
 
@@ -78,8 +85,10 @@ class PointCloud(BoundedTransformableShape):
         '''Volume of the convex hull of the positions in this PointCloud'''
         return self.convex_hull.volume
     
-    def contains(self, points : Vector3 | ArrayNx3) -> bool:
-        return (self.triangulation.find_simplex(points) != -1).astype(object) # need to cast from numpy bool to Python bool
+    def contains(self, points : Vector3 | ArrayNx3) -> BitVectorN:
+        return np.atleast_1d(
+            self.triangulation.find_simplex(points) != -1
+        ).astype(object) # need to cast from numpy bool to Python bool
 
     def scale(self, scaling_factor : float) -> None:
         self.positions = scaling_factor*self.positions + (1 - scaling_factor)*self.centroid

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -6,12 +6,15 @@ __email__ = 'timotej.bernat@colorado.edu'
 from typing import Optional, Protocol, runtime_checkable
 from abc import abstractmethod
 
+from numpy import ndarray
+
 from ..arraytypes import (
     NumberLike,
     Vector3,
     ArrayNxN,
     ArrayNx3,
     TriangulationIndices,
+    BitVectorN,
 )
 from ..transforms.rigid.application import RigidlyTransformable
 
@@ -34,7 +37,7 @@ class BoundedShape(Protocol):
         ...
         
     @abstractmethod
-    def contains(self, points : Vector3 | ArrayNxN) -> bool: 
+    def contains(self, points : Vector3 | ArrayNxN) -> BitVectorN: 
         '''Whether a given coordinate lies within the boundary of the body'''
         ...
 

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -36,7 +36,12 @@ class BoundedShape(Protocol):
     @abstractmethod
     def contains(self, points : Vector3 | ArrayNxN) -> bool: 
         '''Whether a given coordinate lies within the boundary of the body'''
-        ... 
+        ...
+
+    @abstractmethod
+    def scale(self, scaling_factor : float) -> None:
+        "Scale the shape uniformly about its centroid by the specified factor"
+        ...
 
     @abstractmethod
     def surface_mesh(self, *args, **kwargs) -> tuple[ArrayNx3, TriangulationIndices]:
@@ -60,7 +65,14 @@ class BoundedShape(Protocol):
 
 class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
     '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
-    ...
+    def scaled(self, scaling_factor : float) -> BoundedTransformableShape:
+        """
+        Return scaled copy of this shape
+        """ 
+        new_shape = self.copy() # works because RigidlyTransformable is also expected to be copyable
+        new_shape.scale(scaling_factor)
+        
+        return new_shape
         
 class Shaped(Protocol):
     '''Interface for objects which have an associated bounded, tranformable shape'''

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -44,8 +44,10 @@ class BoundedShape(Protocol):
         ...
 
     # NB: deliberately NOT abstract - supplies implementation in case of explicit inheritance
-    def __eq__(self, other :  Self) -> bool:
+    def __eq__(self, other : Self) -> bool:
         # DEV: wrapped here to have concrete subclass impls invoked by super().__eq__
+        if not isinstance(other, BoundedShape):
+            raise TypeError
         return self.congruent_to(other) 
 
     @abstractmethod

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -3,7 +3,8 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Optional, Protocol, runtime_checkable
+from typing import Optional, Self
+from typing import Protocol, runtime_checkable
 from abc import abstractmethod
 
 from ..arraytypes import (
@@ -37,6 +38,14 @@ class BoundedShape(Protocol):
         '''Whether a given coordinate lies within the boundary of the body'''
         ...
 
+    def congruent_to(self, other : Self) -> bool:
+        '''Check if another BoundedShape instance has the same size and shape as this one'''
+        ...
+
+    def __eq__(self, other :  Self) -> bool:
+        # DEV: wrapped here to have concrete subclass impls invoked by super().__eq__
+        return self.congruent_to(other) 
+
     @abstractmethod
     def scale(self, scaling_factor : float) -> None:
         '''Scale the shape uniformly about its centroid by the specified factor'''
@@ -65,13 +74,14 @@ class BoundedShape(Protocol):
 class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
     '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
     def scaled(self, scaling_factor : float) -> 'BoundedTransformableShape':
-        """
-        Return scaled copy of this shape
-        """ 
+        '''Return a scaled copy of this shape'''
         new_shape = self.copy() # works because RigidlyTransformable is also expected to be copyable
         new_shape.scale(scaling_factor)
         
         return new_shape
+    
+    def __eq__(self, other : Self) -> bool:
+        return super().__eq__(other) and self.transformed_like(other)
         
 class Shaped(Protocol):
     '''Interface for objects which have an associated bounded, tranformable shape'''

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -1,0 +1,96 @@
+'''Interfaces for shaped objects and other types which handle them'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+from typing import Optional, Protocol, runtime_checkable
+from abc import abstractmethod
+
+from ..arraytypes import (
+    NumberLike,
+    Vector3,
+    ArrayNxN,
+    ArrayNx3,
+    TriangulationIndices,
+)
+from ..transforms.rigid.application import RigidlyTransformable
+
+
+@runtime_checkable # TODO: make class which composes transformability and boundedness (not necessarily the same a priori)
+class BoundedShape(Protocol):
+    '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
+    # measures of extent
+    @property
+    @abstractmethod
+    def centroid(self) -> Vector3:
+        '''Coordinate of the geometric center of the body'''
+        ...
+    # COM = CoM = center_of_mass = centroid # aliases for convenience
+    
+    @property
+    @abstractmethod
+    def volume(self) -> NumberLike:
+        '''Cumulative measure within the boundary of the body'''
+        ...
+        
+    @abstractmethod
+    def contains(self, points : Vector3 | ArrayNxN) -> bool: 
+        '''Whether a given coordinate lies within the boundary of the body'''
+        ... 
+
+    @abstractmethod
+    def surface_mesh(self, *args, **kwargs) -> tuple[ArrayNx3, TriangulationIndices]:
+        '''
+        Generate a triangulated mesh of the surface of the shape which can be easily digested and plotted by mpl.plot_trisurf
+        
+        Returns
+        -------
+        mesh_points : Array[[N, 3], Numeric]
+            An Nx3 array of the XYZ positions of each point in the mesh
+        tri_vertices : Array[[T, 3], int]
+            A Tx3 array describing the T triples in the mesh, with each row being the triples of array indices of that triangle
+            For example, a row with [1,3,6] represents the triangle traversed counterclockwise from vertices 1 -> 3 -> 6 -> 1
+        '''
+        ...
+    
+    # @abstractmethod
+    # def support(self, direction : np.ndarray[Shape[3], Numeric]) -> np.ndarray[Shape[3], Numeric]:
+    #     '''Determines the furthest point on the surface of the body in a given direction'''
+    #     ...
+
+class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
+    '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
+    ...
+        
+class Shaped(Protocol):
+    '''Interface for objects which have an associated bounded, tranformable shape'''
+    _shape : Optional[BoundedTransformableShape]
+    
+    @property
+    def has_shape(self) -> bool:
+        '''Whether this Primitive has an associated external shape'''
+        return self._shape is not None
+    
+    @property
+    def shape(self) -> Optional[BoundedTransformableShape]: # TODO: make ShapedPrimitive subtype to avoid all these None checks?
+        '''The external shape of this Primitive'''
+        return self._shape
+    
+    @shape.setter
+    def shape(self, new_shape : Optional[BoundedTransformableShape]) -> None:
+        '''Set the external shape of this Primitive with another BoundedShape'''
+        # Case 1) no shape
+        if new_shape is None:
+            self._shape = None
+            return
+        
+        # Case 2) valid shape, which may need to have transformation history transferred over
+        if not isinstance(new_shape, BoundedTransformableShape):
+            raise TypeError(f'Primitive shape must be BoundedShape instance, not object of type {type(new_shape.__name__)}')
+
+        new_shape_clone = new_shape.copy() # NOTE: make copy to avoid mutating original (per Principle of Least Astonishment)
+        if self._shape is not None:
+            new_shape_clone.cumulative_transformation = self._shape.cumulative_transformation # transfer translation history BEFORE overwriting
+        
+        self._shape = new_shape_clone
+        

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -34,7 +34,7 @@ class BoundedShape(Protocol):
         ...
         
     @abstractmethod
-    def contains(self, points : Vector3 | ArrayNxN) -> BitVectorN: 
+    def contains(self, points : Vector3 | ArrayNx3) -> BitVectorN: 
         '''Whether a given coordinate lies within the boundary of the body'''
         ...
 
@@ -113,7 +113,7 @@ class Shaped(Protocol):
         
         # Case 2) valid shape, which may need to have transformation history transferred over
         if not isinstance(new_shape, BoundedTransformableShape):
-            raise TypeError(f'Primitive shape must be BoundedShape instance, not object of type {type(new_shape.__name__)}')
+            raise TypeError(f'Primitive shape must be BoundedTransformableShape instance, not object of type {type(new_shape).__name__}')
 
         new_shape_clone = new_shape.copy() # NOTE: make copy to avoid mutating original (per Principle of Least Astonishment)
         if self._shape is not None:

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -6,8 +6,6 @@ __email__ = 'timotej.bernat@colorado.edu'
 from typing import Optional, Protocol, runtime_checkable
 from abc import abstractmethod
 
-from numpy import ndarray
-
 from ..arraytypes import (
     NumberLike,
     Vector3,
@@ -19,16 +17,14 @@ from ..arraytypes import (
 from ..transforms.rigid.application import RigidlyTransformable
 
 
-@runtime_checkable # TODO: make class which composes transformability and boundedness (not necessarily the same a priori)
+@runtime_checkable
 class BoundedShape(Protocol):
     '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
-    # measures of extent
     @property
     @abstractmethod
     def centroid(self) -> Vector3:
         '''Coordinate of the geometric center of the body'''
         ...
-    # COM = CoM = center_of_mass = centroid # aliases for convenience
     
     @property
     @abstractmethod
@@ -43,7 +39,7 @@ class BoundedShape(Protocol):
 
     @abstractmethod
     def scale(self, scaling_factor : float) -> None:
-        "Scale the shape uniformly about its centroid by the specified factor"
+        '''Scale the shape uniformly about its centroid by the specified factor'''
         ...
 
     @abstractmethod
@@ -62,8 +58,8 @@ class BoundedShape(Protocol):
         ...
     
     # @abstractmethod
-    # def support(self, direction : np.ndarray[Shape[3], Numeric]) -> np.ndarray[Shape[3], Numeric]:
-    #     '''Determines the furthest point on the surface of the body in a given direction'''
+    # def support(self, direction : Vector3) -> Vector3:
+    #     '''Returns the coordinates of the furthest point on the surface of the body in the given direction'''
     #     ...
 
 class BoundedTransformableShape(BoundedShape, RigidlyTransformable):

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -47,7 +47,7 @@ class BoundedShape(Protocol):
     def __eq__(self, other : Self) -> bool:
         # DEV: wrapped here to have concrete subclass impls invoked by super().__eq__
         if not isinstance(other, BoundedShape):
-            raise TypeError
+            raise TypeError(f'Cannot compare BoundedShape to object of type {type(other).__name__}')
         return self.congruent_to(other) 
 
     @abstractmethod
@@ -85,6 +85,8 @@ class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
         return new_shape
     
     def __eq__(self, other : Self) -> bool:
+        if not isinstance(other, BoundedTransformableShape):
+            raise TypeError(f'Cannot compare BoundedTransformableShape to object of type {type(other).__name__}')
         return super().__eq__(other) and self.transformed_like(other)
         
 class Shaped(Protocol):

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -1,8 +1,5 @@
 '''Interfaces for shaped objects and other types which handle them'''
 
-__author__ = 'Timotej Bernat'
-__email__ = 'timotej.bernat@colorado.edu'
-
 from typing import Optional, Self
 from typing import Protocol, runtime_checkable
 from abc import abstractmethod

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -68,7 +68,7 @@ class BoundedShape(Protocol):
 
 class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
     '''Interface for bounded rigid bodies which can undergo coordinate transforms'''
-    def scaled(self, scaling_factor : float) -> BoundedTransformableShape:
+    def scaled(self, scaling_factor : float) -> 'BoundedTransformableShape':
         """
         Return scaled copy of this shape
         """ 

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -47,7 +47,7 @@ class BoundedShape(Protocol):
     def __eq__(self, other : Self) -> bool:
         # DEV: wrapped here to have concrete subclass impls invoked by super().__eq__
         if not isinstance(other, BoundedShape):
-            raise TypeError(f'Cannot compare BoundedShape to object of type {type(other).__name__}')
+            return False
         return self.congruent_to(other) 
 
     @abstractmethod
@@ -86,7 +86,7 @@ class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
     
     def __eq__(self, other : Self) -> bool:
         if not isinstance(other, BoundedTransformableShape):
-            raise TypeError(f'Cannot compare BoundedTransformableShape to object of type {type(other).__name__}')
+            return False
         return super().__eq__(other) and self.transformed_like(other)
         
 class Shaped(Protocol):

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -38,10 +38,12 @@ class BoundedShape(Protocol):
         '''Whether a given coordinate lies within the boundary of the body'''
         ...
 
+    @abstractmethod
     def congruent_to(self, other : Self) -> bool:
         '''Check if another BoundedShape instance has the same size and shape as this one'''
         ...
 
+    # NB: deliberately NOT abstract - supplies implementation in case of explicit inheritance
     def __eq__(self, other :  Self) -> bool:
         # DEV: wrapped here to have concrete subclass impls invoked by super().__eq__
         return self.congruent_to(other) 

--- a/mupt/geometry/shapes/shapes.py
+++ b/mupt/geometry/shapes/shapes.py
@@ -46,7 +46,7 @@ class BoundedShape(Protocol):
     # NB: deliberately NOT abstract - supplies implementation in case of explicit inheritance
     def __eq__(self, other : Self) -> bool:
         # DEV: wrapped here to have concrete subclass impls invoked by super().__eq__
-        if not isinstance(other, BoundedShape):
+        if not isinstance(other, type(self)):
             return False
         return self.congruent_to(other) 
 
@@ -85,8 +85,6 @@ class BoundedTransformableShape(BoundedShape, RigidlyTransformable):
         return new_shape
     
     def __eq__(self, other : Self) -> bool:
-        if not isinstance(other, BoundedTransformableShape):
-            return False
         return super().__eq__(other) and self.transformed_like(other)
         
 class Shaped(Protocol):

--- a/mupt/geometry/shapes/visualize.py
+++ b/mupt/geometry/shapes/visualize.py
@@ -1,0 +1,48 @@
+'''Convenience utilities for drawing shaped objects'''
+
+from typing import Any, Optional
+from inspect import signature
+
+from matplotlib.axes import Axes # DEV: eventually, declare explicit dependency on mpl...
+from mpl_toolkits.mplot3d import Axes3D # ...(maybe even import conditionally?)
+from matplotlib.pyplot import figure
+
+from .shapes import BoundedShape
+
+
+def visualize_shape(
+    shape : BoundedShape,
+    ax : Optional[Axes3D]=None,
+    grid : bool=True, 
+    **kwargs,
+) -> Axes3D:
+    '''Convenience interface for plotting a surface mesh for a class implementing the BoundedShape Protocol'''
+    if ax is None:
+        fig = figure()
+        ax = fig.add_subplot(
+            projection='3d',
+            autoscale_on=True,
+        )
+    elif not isinstance(ax, Axes):
+        raise TypeError(f'Require matplotlib Axes-like for shape mesh drawing, not {type(ax).__name__}')
+    elif not isinstance(ax, Axes3D):
+        raise ValueError('Provided Axes are not 3D, and cannot support shape mesh drawing')
+
+    if grid:
+        ax.set_axis_on()
+    else:
+        ax.set_axis_off()
+
+    valid_mesh_kws : set[str] = signature(shape.surface_mesh).parameters.keys() - {'self'}
+    mesh_kwargs : dict[str, Any] = {
+        kw : kwargs.pop(kw)
+            for kw in valid_mesh_kws
+                if kw in kwargs
+    }
+
+    vertices, triangles = shape.surface_mesh(**mesh_kwargs)
+    ax.plot_trisurf(*vertices.T, triangles=triangles, **kwargs)
+    ax.set_title(type(shape).__name__)
+    ax.set_aspect('equal') # avoids scaling distortion along axes (otherwise, Ellipsoids would plot like Spheres)
+    
+    return ax

--- a/mupt/geometry/shapes/visualize.py
+++ b/mupt/geometry/shapes/visualize.py
@@ -19,15 +19,14 @@ def visualize_shape(
     '''Convenience interface for plotting a surface mesh for a class implementing the BoundedShape Protocol'''
     if ax is None:
         fig = figure()
-        ax = fig.add_subplot(
-            projection='3d',
-            autoscale_on=True,
-        )
+        ax = fig.add_subplot(projection='3d')
     elif not isinstance(ax, Axes):
         raise TypeError(f'Require matplotlib Axes-like for shape mesh drawing, not {type(ax).__name__}')
     elif not isinstance(ax, Axes3D):
         raise ValueError('Provided Axes are not 3D, and cannot support shape mesh drawing')
 
+    fig.set_tight_layout(True)
+    ax.set_autoscale_on(True)
     if grid:
         ax.set_axis_on()
     else:

--- a/mupt/geometry/shapes/visualize.py
+++ b/mupt/geometry/shapes/visualize.py
@@ -6,8 +6,7 @@ from inspect import signature
 from .shapes import BoundedShape
 
 if TYPE_CHECKING:
-    from matplotlib.axes import Axes # DEV: eventually, declare explicit dependency on mpl...
-    from mpl_toolkits.mplot3d import Axes3D # ...(maybe even import conditionally?)
+    from mpl_toolkits.mplot3d import Axes3D
 
 
 def visualize_shape(
@@ -17,6 +16,7 @@ def visualize_shape(
     **kwargs,
 ) -> 'Axes3D':
     '''Convenience interface for plotting a surface mesh for a class implementing the BoundedShape Protocol'''
+    # DEV TODO: eventually, have a more standardized way to deal with these kinds of dependencies on import (a la @requires(...))
     try:
         from matplotlib.axes import Axes
         from mpl_toolkits.mplot3d import Axes3D

--- a/mupt/geometry/shapes/visualize.py
+++ b/mupt/geometry/shapes/visualize.py
@@ -18,14 +18,13 @@ def visualize_shape(
 ) -> Axes3D:
     '''Convenience interface for plotting a surface mesh for a class implementing the BoundedShape Protocol'''
     if ax is None:
-        fig = figure()
+        fig = figure(layout='tight')
         ax = fig.add_subplot(projection='3d')
     elif not isinstance(ax, Axes):
         raise TypeError(f'Require matplotlib Axes-like for shape mesh drawing, not {type(ax).__name__}')
     elif not isinstance(ax, Axes3D):
         raise ValueError('Provided Axes are not 3D, and cannot support shape mesh drawing')
 
-    fig.set_tight_layout(True)
     ax.set_autoscale_on(True)
     if grid:
         ax.set_axis_on()

--- a/mupt/geometry/shapes/visualize.py
+++ b/mupt/geometry/shapes/visualize.py
@@ -1,22 +1,31 @@
 '''Convenience utilities for drawing shaped objects'''
 
-from typing import Any, Optional
+from typing import Any, Optional, TYPE_CHECKING
 from inspect import signature
 
-from matplotlib.axes import Axes # DEV: eventually, declare explicit dependency on mpl...
-from mpl_toolkits.mplot3d import Axes3D # ...(maybe even import conditionally?)
-from matplotlib.pyplot import figure
-
 from .shapes import BoundedShape
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes # DEV: eventually, declare explicit dependency on mpl...
+    from mpl_toolkits.mplot3d import Axes3D # ...(maybe even import conditionally?)
 
 
 def visualize_shape(
     shape : BoundedShape,
-    ax : Optional[Axes3D]=None,
+    ax : Optional['Axes3D']=None,
     grid : bool=True, 
     **kwargs,
-) -> Axes3D:
+) -> 'Axes3D':
     '''Convenience interface for plotting a surface mesh for a class implementing the BoundedShape Protocol'''
+    try:
+        from matplotlib.axes import Axes
+        from mpl_toolkits.mplot3d import Axes3D
+        from matplotlib.pyplot import figure
+    except ImportError as exc:
+        raise RuntimeError(
+            'matplotlib is required to use visualize_shape(); install matplotlib to enable shape visualization'
+        ) from exc
+
     if ax is None:
         fig = figure(layout='tight')
         ax = fig.add_subplot(projection='3d')

--- a/mupt/geometry/shapes/visualize.py
+++ b/mupt/geometry/shapes/visualize.py
@@ -15,8 +15,49 @@ def visualize_shape(
     grid : bool=True, 
     **kwargs,
 ) -> 'Axes3D':
-    '''Convenience interface for plotting a surface mesh for a class implementing the BoundedShape Protocol'''
-    # DEV TODO: eventually, have a more standardized way to deal with these kinds of dependencies on import (a la @requires(...))
+    '''
+    Convenience function for plotting a surface mesh
+    for a class implementing the BoundedShape Protocol
+
+    Parameters
+    ----------
+    shape : BoundedShape
+        Any object whose type implements the BoundedShape
+        Protocol, namely BoundedShape.surface_mesh()
+    ax : Optional[mpl.Axes3D], default None
+        The 3-dimensional matplotlib Axes to plot the mesh onto
+        If NoneType is provided, will generate a new Axes3D and return it
+
+        Provided to support chained plotting workflows (i.e. plot shape onto axes with other meshes)
+    grid : bool, default True
+        Whether or not to show the coordinate axis gridlines when plotting
+    **kwargs 
+        Contains keyword arguments which are passed on to:
+        * The particular implementation of BoundedShape.surface_mesh() for the subtype
+          of shape being plotted (e.g. Sphere and Ellipsoid accept "n_theta" and "n_phi" mesh parameters)
+          
+          For example:
+          >> from mupt.geometry.shapes.ellipsoid import Sphere
+          >> shape = Sphere(1)
+          >> visualize_shape(shape, n_theta=50)
+
+        * Axes3D.plot_trisurf() (https://matplotlib.org/stable/api/_as_gen/mpl_toolkits.mplot3d.axes3d.Axes3D.plot_trisurf.html)
+          
+          Acceptable values are anything arguments which can be passed into a
+          matplotlib.collections.Collection, namely attributes assignable by Collection.set() 
+          (https://matplotlib.org/stable/api/collections_api.html#matplotlib.collections.Collection.set)
+
+          "color", "alpha", and "grid" are commonly-used args, viz.:
+          >> visualize_shape(shape, color='b', alpha=0.5)
+
+    Returns
+    -------
+    axes : mpl.Axes3D
+        The 3D axes the BoundedShape has been drawn on
+        Enables chaining plotting operations
+    '''
+    # DEV TODO: eventually, have a more standardized way to deal with 
+    # these kinds of dependencies on import (a la @requires(...))
     try:
         from matplotlib.axes import Axes
         from mpl_toolkits.mplot3d import Axes3D

--- a/mupt/geometry/transforms/linear.py
+++ b/mupt/geometry/transforms/linear.py
@@ -4,10 +4,10 @@ __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
 import numpy as np
-from ..arraytypes import Shape, N, Dims, Numeric
+from ..arraytypes import Shape, Dims, NumericNP, Vector3, Array3x3
 
 
-def projector(normal_vector : np.ndarray[Shape[Dims], Numeric]) -> np.ndarray[Shape[Dims, Dims], Numeric]:
+def projector(normal_vector : np.ndarray[Shape[Dims], NumericNP]) -> np.ndarray[Shape[Dims, Dims], NumericNP]:
     '''
     Computes a linear transformation which, when applied to an arbitrary vector,
     yields the component of that vector parallel to the normal vector provided
@@ -18,7 +18,7 @@ def projector(normal_vector : np.ndarray[Shape[Dims], Numeric]) -> np.ndarray[Sh
     return np.outer(normal_vector, normal_vector) / np.inner(normal_vector, normal_vector)
 parallel = projector
 
-def rejector(normal_vector : np.ndarray[Shape[Dims], Numeric]) -> np.ndarray[Shape[Dims, Dims], Numeric]:
+def rejector(normal_vector : np.ndarray[Shape[Dims], NumericNP]) -> np.ndarray[Shape[Dims, Dims], NumericNP]:
     '''
     Computes a linear transformation which, when applied to an arbitrary vector,
     yields the component of that vector orthogonal to the normal vector provided
@@ -29,7 +29,7 @@ def rejector(normal_vector : np.ndarray[Shape[Dims], Numeric]) -> np.ndarray[Sha
     return np.eye(dim, dtype=normal_vector.dtype) - projector(normal_vector) # equivalent to substracting parallel part off of vector transform is applied to
 orthogonal = rejector
 
-def reflector(normal_vector : np.ndarray[Shape[Dims], Numeric]) -> np.ndarray[Shape[Dims, Dims], Numeric]:
+def reflector(normal_vector : np.ndarray[Shape[Dims], NumericNP]) -> np.ndarray[Shape[Dims, Dims], NumericNP]:
     '''
     Computes a linear transformation which, when applied to an arbitrary vector,
     reflects it across the plane defined by the normal vector provided
@@ -40,7 +40,7 @@ def reflector(normal_vector : np.ndarray[Shape[Dims], Numeric]) -> np.ndarray[Sh
     return np.eye(dim, dtype=normal_vector.dtype) - 2*projector(normal_vector) # compute Householder reflection
 householder = reflector
 
-def orthogonalizer(normal_vector : np.ndarray[Shape[3], Numeric]) -> np.ndarray[Shape[3, 3], Numeric]:
+def orthogonalizer(normal_vector : Vector3) -> Array3x3:
     '''
     Computes a linear transformation which, when applied to an arbitrary vector,
     yields a vector orthogonal to both that vector and the normal vector provided here

--- a/mupt/geometry/transforms/rigid/__init__.py
+++ b/mupt/geometry/transforms/rigid/__init__.py
@@ -36,6 +36,6 @@ def random_rigid_transformation(
         translation_bound = 0.0
     
     return RigidTransform.from_components(
-        translation=(translation_bound *  np.random.rand(3)),
+        translation=np.random.uniform(-translation_bound, translation_bound, size=3),
         rotation=Rotation.random(),
     )

--- a/mupt/geometry/transforms/rigid/__init__.py
+++ b/mupt/geometry/transforms/rigid/__init__.py
@@ -4,6 +4,38 @@ i.e. for working with the Special Euclidean group SE(3)'''
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
+import numpy as np
+from scipy.spatial.transform import Rotation, RigidTransform
+
 from .application import apply_rigid_transformation_recursive, RigidlyTransformable
 from .rotations import rotator, rodrigues, alignment_rotation
 from .alignment import rigid_vector_coalignment
+
+
+def random_rigid_transformation(
+    centered : bool=False,
+    translation_bound : float=1.0,
+) -> RigidTransform:
+    """
+    Generate a random rigid transformation, with both translation and rotation components by default
+
+    Parameters
+    ----------
+    centered : bool, default False
+        Whether the transformation should contain a translational component
+    translation_bound : float, default 1.0
+        Uniform bound along all Cartesian axes for translation component
+        E.g. translation_bound=5.0 will pick a random translation vector from the set [-5, 5]**3
+
+    Returns
+    -------
+    rand_transform : RigidTransform
+        The resulting randomized rigid transformation
+    """
+    if centered:
+        translation_bound = 0.0
+    
+    return RigidTransform.from_components(
+        translation=(translation_bound *  np.random.rand(3)),
+        rotation=Rotation.random(),
+    )

--- a/mupt/geometry/transforms/rigid/__init__.py
+++ b/mupt/geometry/transforms/rigid/__init__.py
@@ -12,30 +12,28 @@ from .rotations import rotator, rodrigues, alignment_rotation
 from .alignment import rigid_vector_coalignment
 
 
-def random_rigid_transformation(
-    centered : bool=False,
-    translation_bound : float=1.0,
-) -> RigidTransform:
+def random_rigid_transformation(translation_bound : float=0.0) -> RigidTransform:
     """
     Generate a random rigid transformation, with both translation and rotation components by default
 
     Parameters
     ----------
-    centered : bool, default False
-        Whether the transformation should contain a translational component
-    translation_bound : float, default 1.0
+    translation_bound : float, default 0.0
         Uniform bound along all Cartesian axes for translation component
-        E.g. translation_bound=5.0 will pick a random translation vector from the set [-5, 5]**3
+        E.g. translation_bound=5.0 will pick a random translation vector from the set [-5.0, 5.0]**3
+
+        If 0.0 bound is provided (default), resulting transformation will have NO translational component
 
     Returns
     -------
     rand_transform : RigidTransform
         The resulting randomized rigid transformation
     """
-    if centered:
-        translation_bound = 0.0
-    
     return RigidTransform.from_components(
-        translation=np.random.uniform(-translation_bound, translation_bound, size=3),
+        translation=np.random.uniform(
+            -translation_bound,
+            translation_bound,
+            size=3,
+        ),
         rotation=Rotation.random(),
     )

--- a/mupt/geometry/transforms/rigid/alignment.py
+++ b/mupt/geometry/transforms/rigid/alignment.py
@@ -3,21 +3,22 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-import numpy as np
+from typing import Optional
+
 from scipy.spatial.transform import RigidTransform
 
 from .rotations import alignment_rotation
-from ...arraytypes import Shape, N, Numeric
+from ...arraytypes import Vector3
 
 
 def rigid_vector_coalignment(
-    vector1_start : np.ndarray[Shape[3], Numeric],
-    vector1_end : np.ndarray[Shape[3], Numeric],
-    vector2_start : np.ndarray[Shape[3], Numeric],
-    vector2_end : np.ndarray[Shape[3], Numeric],
+    vector1_start : Vector3,
+    vector1_end : Vector3,
+    vector2_start : Vector3,
+    vector2_end : Vector3,
     *,
     t1 : float=0.5,
-    t2 : float=None,
+    t2 : Optional[float]=None,
 ) -> RigidTransform:
     '''
     Compute a rigid transformation that forces "vector1" (defined by its end points and not necessarily emanating from the origin)

--- a/mupt/geometry/transforms/rigid/application.py
+++ b/mupt/geometry/transforms/rigid/application.py
@@ -5,7 +5,7 @@ __email__ = 'timotej.bernat@colorado.edu'
 
 from typing import Any, Mapping, Self, Sequence, Union
 from typing import Protocol, runtime_checkable
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from scipy.spatial.transform import RigidTransform
 
@@ -13,7 +13,7 @@ from ....mutils.copyable import Copyable, NotCopyableError
 
 
 @runtime_checkable
-class RigidlyTransformable(Protocol):
+class RigidlyTransformable(Copyable, Protocol):
     '''Mixin for objects which support rigid transformations'''
     # DEV: went back and forth on verbiage, but settled on the following as least ambiguous:
     # * "transformation" to refer to the RigidTransforms passed around
@@ -22,6 +22,8 @@ class RigidlyTransformable(Protocol):
     # DON'T change these names until you've understood this and made similar considerations for proposed changes
 
     # transform provenance
+    _cumul_transf : RigidTransform 
+    
     @property
     def cumulative_transformation(self) -> RigidTransform:
         '''
@@ -59,9 +61,7 @@ class RigidlyTransformable(Protocol):
         self.rigidly_transform(self.resetting_transformation)
 
     # copying and out-of-place applications of transformations
-
-    ## DEV: _copy_untransformed() is deliberately NOT an abstract method, as it's not required that child classes implement it;
-    ## ...if children don't implement it, they simply won't be able to perform copying or out-of-place transformations
+    @abstractmethod
     def _copy_untransformed(self) -> Self:
         '''Defines how to make a copy of an object with the same internal parts, but  without preserving it's cumulative transformation'''
         raise NotCopyableError(f'Class {self.__class__.__name__} does not define how instances should copy their parts')
@@ -73,6 +73,7 @@ class RigidlyTransformable(Protocol):
         
         return new_obj
 
+    # out-of-place applications of transformations
     def rigidly_transformed(self, transformation: RigidTransform) -> Self:
         '''Return a copy of this object which has been transformed according to the rigid transformation provided'''
         clone = self.copy() # TODO: implement mechanism to transfer cumul transform during copy of child classes
@@ -111,10 +112,11 @@ def apply_rigid_transformation_recursive(
 
     # recursive iteration, as necessary
     if isinstance(obj, Sequence):  # DEVNOTE: specifically opted for Sequence over Iterable here to avoid double-covering Mappings and unpacking generators
-        return type(obj)( # DEVNOTE: most common Sequence types (e.g. tuple, str, list) support init from comprehension; may revisit if this is not always the case
-            apply_rigid_transformation_recursive(value, transformation)
+         # DEVNOTE: most common Sequence types (e.g. tuple, str, list) support init from comprehension; may revisit if this is not always the case
+        return type(obj)(
+            apply_rigid_transformation_recursive(value, transformation) 
                 for value in obj
-        ) 
+        )
     elif isinstance(obj, Mapping):
         return {
             key : apply_rigid_transformation_recursive(value, transformation)

--- a/mupt/geometry/transforms/rigid/application.py
+++ b/mupt/geometry/transforms/rigid/application.py
@@ -6,10 +6,28 @@ __email__ = 'timotej.bernat@colorado.edu'
 from typing import Any, Mapping, Self, Sequence, Union
 from typing import Protocol, runtime_checkable
 
+from numpy import allclose
 from scipy.spatial.transform import RigidTransform
 
 from ....mutils.copyable import Copyable, NotCopyableError
 
+
+def transformations_approx_equal(
+    transformation1 : RigidTransform,
+    transformation2 : RigidTransform,
+    rtol : float = 1E-5,
+    atol : float=1E-8,
+    equal_nan : bool=False,
+) -> bool:
+    '''Check if two RigidTransforms are within '''
+    return allclose(
+        # NOTE: must compare as matrix, as __eq__ does not perform this comparison
+        transformation1.as_matrix(),
+        transformation2.as_matrix(),
+        rtol=rtol,
+        atol=atol,
+        equal_nan=equal_nan,
+    )
 
 @runtime_checkable
 class RigidlyTransformable(Copyable, Protocol):

--- a/mupt/geometry/transforms/rigid/application.py
+++ b/mupt/geometry/transforms/rigid/application.py
@@ -57,6 +57,18 @@ class RigidlyTransformable(Copyable, Protocol):
     def cumulative_transformation(self, transformation : RigidTransform) -> None:
         # DEV: might include some additional checks in here in the future
         self._cumul_transf = transformation
+
+    def transformed_like(self, other : 'RigidlyTransformable', *args, **kwargs) -> bool:
+        '''
+        Whether of not this RigidlyTransformable object has a 
+        cumulative transformation approximately equal to that of another
+        '''
+        return transformations_approx_equal(
+            self.cumulative_transformation,
+            other.cumulative_transformation,
+            *args,
+            **kwargs,
+        )
         
     @property
     def resetting_transformation(self) -> RigidTransform:

--- a/mupt/geometry/transforms/rigid/application.py
+++ b/mupt/geometry/transforms/rigid/application.py
@@ -47,7 +47,6 @@ class RigidlyTransformable(Copyable, Protocol):
         return self.cumulative_transformation.inv()
 
     # in-place application of transformations
-    @abstractmethod
     def _rigidly_transform(self, transformation : RigidTransform) -> None:
         raise NotImplementedError # implement subclass-specific behavior here
         
@@ -61,7 +60,8 @@ class RigidlyTransformable(Copyable, Protocol):
         self.rigidly_transform(self.resetting_transformation)
 
     # copying and out-of-place applications of transformations
-    @abstractmethod
+    ## DEV: _copy_untransformed() is deliberately NOT an abstract method, as it's not required that child classes implement it;
+    ## ...if children don't implement it, they simply won't be able to perform copying or out-of-place transformations
     def _copy_untransformed(self) -> Self:
         '''Defines how to make a copy of an object with the same internal parts, but  without preserving it's cumulative transformation'''
         raise NotCopyableError(f'Class {self.__class__.__name__} does not define how instances should copy their parts')
@@ -87,9 +87,9 @@ class RigidlyTransformable(Copyable, Protocol):
         
         
 def apply_rigid_transformation_recursive(
-        obj : Union[object, Sequence[Any], Mapping[str, Any]],
-        transformation: RigidTransform,
-    ) -> Union[object, Sequence[Any], dict[str, Any]]:
+    obj : Union[object, Sequence[Any], Mapping[str, Any]],
+    transformation: RigidTransform,
+) -> Union[object, Sequence[Any], dict[str, Any]]:
     '''Apply a rigid transformation to an object, if it supports such a transformation, and
     if the object is a Sequence or Mapping, attempt to transform its members recursively
     

--- a/mupt/geometry/transforms/rigid/application.py
+++ b/mupt/geometry/transforms/rigid/application.py
@@ -5,7 +5,6 @@ __email__ = 'timotej.bernat@colorado.edu'
 
 from typing import Any, Mapping, Self, Sequence, Union
 from typing import Protocol, runtime_checkable
-from abc import abstractmethod
 
 from scipy.spatial.transform import RigidTransform
 

--- a/mupt/geometry/transforms/rigid/rotations.py
+++ b/mupt/geometry/transforms/rigid/rotations.py
@@ -7,14 +7,14 @@ import numpy as np
 from scipy.spatial.transform import Rotation
 
 from ..linear import reflector, orthogonalizer
-from ...arraytypes import Shape, Numeric
+from ...arraytypes import Vector3
 from ...measure import normalized
 
 from ...coordinates.basis import is_orthogonal
 
 
 def rotator(
-    rotation_axis : np.ndarray[Shape[3], Numeric],
+    rotation_axis : Vector3,
     angle_rad : float=0.0,
 ) -> Rotation:
     ''' 
@@ -36,8 +36,8 @@ def rotator(
 rodrigues = rotator
 
 def alignment_rotation(
-    moved_vector : np.ndarray[Shape[3], Numeric],
-    onto_vector : np.ndarray[Shape[3], Numeric],
+    moved_vector : Vector3,
+    onto_vector : Vector3,
 ) -> Rotation:
     '''
     Compute a rotation which takes moved_vector parallel to the span of onto_vector

--- a/mupt/mupr/connection.py
+++ b/mupt/mupr/connection.py
@@ -30,8 +30,8 @@ import numpy as np
 from scipy.spatial.transform import Rotation, RigidTransform
 
 from ..chemistry.core import BondType
-from ..geometry.arraytypes import Shape, Vector3, as_n_vector, compare_optional_positions
-from ..geometry.measure import within_ball
+from ..geometry.arraytypes import Shape, Vector3, as_n_vector
+from ..geometry.measure import compare_optional_positions
 from ..geometry.coordinates.basis import is_orthonormal
 from ..geometry.transforms.linear import rejector
 from ..geometry.transforms.rigid.rotations import alignment_rotation
@@ -109,7 +109,7 @@ class AttachmentPoint(RigidlyTransformable):
             if (value is not None) and (value not in self.attachables):
                 raise ValueError(f'Attachment "{value!s}" not designated as one of attachable labels {self.attachables}')
         if key == 'position':
-            value = as_n_vector(value, 3)
+            value = as_n_vector(value, dimension=3)
         return super().__setattr__(key, value)
         
     # Implementing RigidTransformable contracts
@@ -182,7 +182,7 @@ class Connector(RigidlyTransformable):
     @bond_vector.setter
     def bond_vector(self, new_bond_vector : Vector3) -> None:
         # TODO: cast this as a rigid transformation of linker to track cumulative transform? (would enable reset of bond length history)
-        self.linker.position = as_n_vector(new_bond_vector, 3) + self.anchor.position
+        self.linker.position = as_n_vector(new_bond_vector, dimension=3) + self.anchor.position
         
     @property
     def bond_length(self) -> float:
@@ -219,7 +219,7 @@ class Connector(RigidlyTransformable):
     @tangent_vector.setter
     def tangent_vector(self, new_tangent_vector : Vector3) -> None:
         '''Update tangent positions given a new tangent vector'''
-        new_tangent_vector = as_n_vector(new_tangent_vector, 3)
+        new_tangent_vector = as_n_vector(new_tangent_vector, dimension=3)
         if not np.isclose(
             np.dot( # DEV: opting not to normalize here in case either vector has small magnitude - revisit if that becomes an issue
                 self.bond_vector,
@@ -289,7 +289,7 @@ class Connector(RigidlyTransformable):
             metadata=deepcopy(self.metadata),
         )
         if self.has_tangent_position:
-            new_connector.tangent_vector = as_n_vector(self.tangent_vector, 3)
+            new_connector.tangent_vector = as_n_vector(self.tangent_vector, dimension=3)
 
         return new_connector
 
@@ -310,12 +310,12 @@ class Connector(RigidlyTransformable):
         of the other Connector, and vice-versa (with the same tolerance for both)
         '''
         return (
-            within_ball(
+            compare_optional_positions(
                 self.anchor.position,
                 other.linker.position,
                 radius=within,
             )
-            and within_ball(
+            and compare_optional_positions(
                 self.linker.position,
                 other.anchor.position,
                 radius=within,

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -1049,7 +1049,7 @@ class Primitive(NodeMixin, RigidlyTransformable):
     def shape(self, new_shape : BoundedTransformableShape) -> None:
         '''Set the external shape of this Primitive'''
         if not isinstance(new_shape, BoundedTransformableShape):
-            raise TypeError(f'Primitive shape must be BoundedTransformableShape instance, not object of type {type(new_shape.__name__)}')
+            raise TypeError(f'Primitive shape must be BoundedTransformableShape instance, not object of type {type(new_shape).__name__}')
 
         new_shape_clone = new_shape.copy() # NOTE: make copy to avoid mutating original (per Principle of Least Astonishment)
         if self._shape is not None:

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -54,7 +54,7 @@ from .topology import TopologicalStructure, GraphLayout
 from .embedding import infer_connections_from_topology, ConnectorReference, flexible_connector_reference
 
 from ..mutils.containers import UniqueRegistry
-from ..geometry.shapes import BoundedShape
+from ..geometry.shapes import BoundedTransformableShape
 from ..geometry.transforms.rigid import RigidlyTransformable
 from ..chemistry.core import ElementLike, isatom, BOND_ORDER, valence_allowed
 from ..roles import PrimitiveRole
@@ -85,7 +85,7 @@ class Primitive(NodeMixin, RigidlyTransformable):
     
     Parameters
     ----------
-    shape : Optional[BoundedShape]
+    shape : Optional[BoundedTransformableShape]
         A rigid shape which approximates and abstracts the behavior of the primitive in space
     element : Optional[Union[Element, Ion, Isotope]]
         The chemical element associated with this Primitive, IFF the Primitive represents an atom
@@ -105,7 +105,7 @@ class Primitive(NodeMixin, RigidlyTransformable):
     # Initializers
     def __init__(
         self, # DEV: force all args to be KW-only?
-        shape : Optional[BoundedShape]=None,
+        shape : Optional[BoundedTransformableShape]=None,
         element : Optional[ElementLike]=None,
         connectors : Optional[Iterable[Connector]]=None,
         children : Optional[Iterable['Primitive']]=None,
@@ -911,7 +911,7 @@ class Primitive(NodeMixin, RigidlyTransformable):
         self,
         target_labels : set[PrimitiveHandle],
         master_label : PrimitiveHandle,
-        new_shape : Optional[BoundedShape]=None,
+        new_shape : Optional[BoundedTransformableShape]=None,
     ) -> None:
         '''
         Insert a new level into the hierarchy and group the selected
@@ -1041,15 +1041,15 @@ class Primitive(NodeMixin, RigidlyTransformable):
 
     # Geometry (info about Shape and transformations)
     @property
-    def shape(self) -> Optional[BoundedShape]:
+    def shape(self) -> Optional[BoundedTransformableShape]:
         '''The external shape of this Primitive'''
         return self._shape
     
     @shape.setter
-    def shape(self, new_shape : BoundedShape) -> None:
+    def shape(self, new_shape : BoundedTransformableShape) -> None:
         '''Set the external shape of this Primitive'''
-        if not isinstance(new_shape, BoundedShape):
-            raise TypeError(f'Primitive shape must be BoundedShape instance, not object of type {type(new_shape.__name__)}')
+        if not isinstance(new_shape, BoundedTransformableShape):
+            raise TypeError(f'Primitive shape must be BoundedTransformableShape instance, not object of type {type(new_shape.__name__)}')
 
         new_shape_clone = new_shape.copy() # NOTE: make copy to avoid mutating original (per Principle of Least Astonishment)
         if self._shape is not None:
@@ -1061,7 +1061,7 @@ class Primitive(NodeMixin, RigidlyTransformable):
     def _copy_untransformed(self) -> 'Primitive':
         '''Return a new Primitive with the same information and children as this one, but which has no parent'''
         clone_primitive = self.__class__(
-            shape=(None if self.shape is None else self.shape.copy()),
+            shape=(None if self.shape is None else self.shape.copy()), # DEV TODO: should be _copy_untransformed()?
             element=self.element,
             # NOTE: connectors and children transferred verbatim below - no need to set in init here
             connectors=None, 
@@ -1098,7 +1098,7 @@ class Primitive(NodeMixin, RigidlyTransformable):
     
     def _rigidly_transform(self, transformation : RigidTransform) -> None: 
         '''Apply a rigid transformation to all parts of a Primitive which support it'''
-        if isinstance(self.shape, BoundedShape):
+        if isinstance(self.shape, BoundedTransformableShape):
             self.shape.rigidly_transform(transformation)
         
         for connector in self.connectors.values():

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -1061,7 +1061,7 @@ class Primitive(NodeMixin, RigidlyTransformable):
     def _copy_untransformed(self) -> 'Primitive':
         '''Return a new Primitive with the same information and children as this one, but which has no parent'''
         clone_primitive = self.__class__(
-            shape=(None if self.shape is None else self.shape.copy()), # DEV TODO: should be _copy_untransformed()?
+            shape=self.shape, # handles unset NoneType case natively
             element=self.element,
             # NOTE: connectors and children transferred verbatim below - no need to set in init here
             connectors=None, 

--- a/mupt/mutils/containers.py
+++ b/mupt/mutils/containers.py
@@ -25,7 +25,7 @@ class Labelled(Protocol):
         
 LabelT = TypeVar('LabelT', bound=Hashable)
 HandleT = tuple[LabelT, int] # label uniquified with an additional arbitrary index
-LabelledT = TypeVar('LabelledT')
+LabelledT = TypeVar('LabelledT', bound=Labelled)
 
 class UniqueRegistry(UserDict, Generic[LabelT, LabelledT]):
     '''
@@ -70,8 +70,10 @@ class UniqueRegistry(UserDict, Generic[LabelT, LabelledT]):
         '''Privatized version of __setitem__ - intend for internal use when copying UniqueRegistry objects'''
         super().__setitem__(key, item)
 
-    def register(self, obj: LabelledT, label : Optional[LabelT]) -> HandleT:
+    def register(self, obj: LabelledT, label : Optional[LabelT]=None) -> HandleT:
         '''Generate a new, unique handle for the given object and register it, then return the handle'''
+        if label is None:
+            label = obj.label # DEV: opted for behavioral pattern, rather than explicit runtime_checkable Protocol enforcement
         handle = (label, self._get_uniquifying_index(label))
         super().__setitem__(handle, obj)
 
@@ -82,7 +84,7 @@ class UniqueRegistry(UserDict, Generic[LabelT, LabelledT]):
         handles : list[HandleT] = []
         if isinstance(collection, Mapping):
             for label, obj in collection.items():
-                handles.append(self.register(obj, label=label)) # type: ignore
+                handles.append(self.register(obj, label=label))
         else:
             for obj in collection:
                 handles.append(self.register(obj, label=None))

--- a/mupt/mutils/containers.py
+++ b/mupt/mutils/containers.py
@@ -17,15 +17,15 @@ from collections import Counter, UserDict, defaultdict
 from copy import deepcopy
 
 
-LabelT = TypeVar('LabelT', bound=Hashable)
-HandleT = tuple[LabelT, int] # label uniquified with an additional arbitrary index
-
 class Labelled(Protocol):
     '''Protocol for objects that have a label'''
     @property
     def label(self) -> Hashable: 
         ...
-LabelledT = TypeVar('LabelledT', bound=Labelled)
+        
+LabelT = TypeVar('LabelT', bound=Hashable)
+HandleT = tuple[LabelT, int] # label uniquified with an additional arbitrary index
+LabelledT = TypeVar('LabelledT')
 
 class UniqueRegistry(UserDict, Generic[LabelT, LabelledT]):
     '''
@@ -38,8 +38,8 @@ class UniqueRegistry(UserDict, Generic[LabelT, LabelledT]):
         self._freed = defaultdict(set)
 
     # Unique index ticker management
-    def _take_connector_number(self, label : LabelT) -> int:
-        '''Increment and return the next available integer for uniquifying a Connector label'''
+    def _get_uniquifying_index(self, label : Optional[LabelT]) -> int:
+        '''Increment and return the next available integer for uniquifying a label'''
         if len(freed_idxs := self._freed[label]) > 0:
             idx = min(freed_idxs)
             self._freed[label].remove(idx)
@@ -70,21 +70,19 @@ class UniqueRegistry(UserDict, Generic[LabelT, LabelledT]):
         '''Privatized version of __setitem__ - intend for internal use when copying UniqueRegistry objects'''
         super().__setitem__(key, item)
 
-    def register(self, obj: LabelledT, label : Optional[LabelT]=None) -> HandleT:
+    def register(self, obj: LabelledT, label : Optional[LabelT]) -> HandleT:
         '''Generate a new, unique handle for the given object and register it, then return the handle'''
-        if label is None:
-            label = obj.label # DEV: opted for behavioral pattern, rather than explicit runtime_checkable Protocol enforcement
-        handle = (label, self._take_connector_number(label))
+        handle = (label, self._get_uniquifying_index(label))
         super().__setitem__(handle, obj)
 
         return handle
     
-    def register_from(self, collection : Iterable[LabelledT]) -> list[HandleT]:
+    def register_from(self, collection : Iterable[LabelledT] | Mapping[LabelT, LabelledT]) -> list[HandleT]:
         '''Register multiple objects at once, returning a list of their assigned handles'''
         handles : list[HandleT] = []
         if isinstance(collection, Mapping):
             for label, obj in collection.items():
-                handles.append(self.register(obj, label=label))
+                handles.append(self.register(obj, label=label)) # type: ignore
         else:
             for obj in collection:
                 handles.append(self.register(obj, label=None))

--- a/mupt/mutils/copyable.py
+++ b/mupt/mutils/copyable.py
@@ -12,6 +12,6 @@ class Copyable(Protocol):
     def copy(self) -> Self:
         ...
 
-class NotCopyableError(Exception):
+class NotCopyableError(NotImplementedError):
     '''Raised when a copy-based operation is invokes on an object whose class doesn't implement it'''
     ...

--- a/mupt/mutils/copyable.py
+++ b/mupt/mutils/copyable.py
@@ -4,7 +4,20 @@ __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
 from typing import Protocol, Self, runtime_checkable
+from functools import cached_property
 
+
+def clear_cached_properties(obj : object) -> None:
+    '''
+    Invalidate all cached_property values on an instance which are:
+    * have been set on the instance
+    * are defined in the corresponding type
+    '''
+    typ = type(obj)
+    for method_name in dir(typ):
+        methodlike = getattr(typ, method_name)
+        if isinstance(methodlike, cached_property) and (method_name in vars(obj)):
+            delattr(obj, method_name)
 
 @runtime_checkable
 class Copyable(Protocol):

--- a/mupt/tests/geometry/test_arraytypes.py
+++ b/mupt/tests/geometry/test_arraytypes.py
@@ -1,0 +1,50 @@
+'''Unit tests for array size and dtype typehinting'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+import pytest
+import numpy as np
+
+from mupt.geometry.arraytypes import (
+    as_n_vector,
+    VectorN,
+)
+
+
+@pytest.fixture
+def vector_expected() -> VectorN:
+    return np.array([1.,2.,3.])
+
+@pytest.mark.parametrize(
+    'vectorlike',
+    [
+        ([1,2,3]),
+        [[1,2,3]],
+        tuple([1,2,3]),
+        np.array([1,2,3]),
+        np.array([1.,2.,3.]),
+        np.array([[1,2,3]]),
+        np.array([[1,2,3]]).T,
+        pytest.param(
+            [1,2,3,4],
+            marks=pytest.mark.xfail(
+                raises=AssertionError,
+                reason='Input vectorlike has the wrong shape',
+                strict=True,
+            )
+        ),
+        pytest.param(
+            '[1,2,3]',
+            marks=pytest.mark.xfail(
+                raises=TypeError,
+                reason='String of numerics is not a valid Sequence of numerics for interpretation as a vector',
+                strict=True,
+            )
+        ),
+    ],
+)
+def test_as_n_vector_shape(vectorlike, vector_expected : VectorN) -> None:
+    '''Test that permissive vector ingestion accepts the kinds of numeric data structures it advertises'''
+    vector_actual = as_n_vector(vectorlike, dimension=None) # suppress internal shape validation
+    assert (vector_actual.size == (vector_expected.size))

--- a/mupt/tests/geometry/test_arraytypes.py
+++ b/mupt/tests/geometry/test_arraytypes.py
@@ -1,8 +1,5 @@
 '''Unit tests for array size and dtype typehinting'''
 
-__author__ = 'Timotej Bernat'
-__email__ = 'timotej.bernat@colorado.edu'
-
 import pytest
 import numpy as np
 

--- a/mupt/tests/geometry/test_rigidly_transformable.py
+++ b/mupt/tests/geometry/test_rigidly_transformable.py
@@ -11,7 +11,10 @@ import numpy as np
 from scipy.spatial.transform import Rotation, RigidTransform
 
 from mupt.mutils.copyable import NotCopyableError
-from mupt.geometry.transforms.rigid.application import RigidlyTransformable
+from mupt.geometry.transforms.rigid.application import (
+    transformations_approx_equal,
+    RigidlyTransformable
+)
 
 
 # dummy classes for testing over
@@ -84,20 +87,19 @@ def test_cumulative_transformation(
         points.rigidly_transform(transform)
         cumul_trans *= transform
         
-    np.testing.assert_allclose(
-        points.cumulative_transformation.as_matrix(), # NOTE: must compare as matrix, as __eq__ does not perform this comparison
-        cumul_trans.as_matrix(),
-        strict=True, # check dtype and shape for completeness
+    assert transformations_approx_equal(
+        points.cumulative_transformation 
+        cumul_trans,
     )
 
 def test_reset_transform(points : Points, transform : RigidTransform):
     '''Test that resetting a rigid transformation in-place return the object to its original state'''
     points.rigidly_transform(transform)
     points.reset_transform()
-    np.testing.assert_allclose(
-        points.cumulative_transformation.as_matrix(),
-        RigidTransform.identity().as_matrix(),
-        strict=True,
+
+    assert transformations_approx_equal(
+        points.cumulative_transformation 
+        RigidTransform.identity(),
     )
 
 ## Test read-only variants of methods

--- a/mupt/tests/geometry/test_rigidly_transformable.py
+++ b/mupt/tests/geometry/test_rigidly_transformable.py
@@ -20,7 +20,7 @@ from mupt.geometry.transforms.rigid.application import (
 # dummy classes for testing over
 class Points(RigidlyTransformable):
     '''Dummy class for testing RigidlyTransformable Protocol'''
-    def __init__(self, positions: np.ndarray):
+    def __init__(self, positions: np.ndarray) -> None:
         self.positions = positions
 
     def _rigidly_transform(self, transform: RigidTransform) -> None:
@@ -31,7 +31,7 @@ class Points(RigidlyTransformable):
     
 class PointsNonCopyable(RigidlyTransformable):
     '''Dummy class for to test that in-place methods fail when copying is undefined'''
-    def __init__(self, positions: np.ndarray):
+    def __init__(self, positions: np.ndarray) -> None:
         self.positions = positions
 
     def _rigidly_transform(self, transform: RigidTransform) -> None:
@@ -66,7 +66,11 @@ def points_non_copyable(sample_positions : np.ndarray) -> PointsNonCopyable:
 
 # Tests
 ## Test in-place methods
-def test_rigidly_transform(points : Points, transform : RigidTransform, sample_positions_transformed : np.ndarray):
+def test_rigidly_transform(
+    points : Points,
+    transform : RigidTransform,
+    sample_positions_transformed : np.ndarray,
+) -> None:
     '''Test that rigid transformation are correctly applied in-place'''
     points.rigidly_transform(transform)
     np.testing.assert_allclose(
@@ -77,10 +81,10 @@ def test_rigidly_transform(points : Points, transform : RigidTransform, sample_p
 
 @pytest.mark.parametrize('num_applications', range(8))
 def test_cumulative_transformation(
-        points : Points,
-        transform : RigidTransform,
-        num_applications : int,
-    ):
+    points : Points,
+    transform : RigidTransform,
+    num_applications : int,
+) -> None:
     '''Test that transformed applied one after the other are correctly accumulated'''
     cumul_trans = RigidTransform.identity()
     for _ in range(num_applications):
@@ -88,7 +92,7 @@ def test_cumulative_transformation(
         cumul_trans *= transform
         
     assert transformations_approx_equal(
-        points.cumulative_transformation 
+        points.cumulative_transformation,
         cumul_trans,
     )
 
@@ -98,7 +102,7 @@ def test_reset_transform(points : Points, transform : RigidTransform):
     points.reset_transform()
 
     assert transformations_approx_equal(
-        points.cumulative_transformation 
+        points.cumulative_transformation,
         RigidTransform.identity(),
     )
 
@@ -106,7 +110,7 @@ def test_reset_transform(points : Points, transform : RigidTransform):
 def test_rigidly_transformed(
     points : Union[Points, PointsNonCopyable],
     transform : RigidTransform,
-):
+) -> None:
     '''Test that rigid transformation are correctly applied in-place'''
     new_points = points.rigidly_transformed(transform)
     # NOTE: will not compare as expected when transform is within float imprecision
@@ -121,14 +125,14 @@ def test_rigidly_transformed(
 def test_rigidly_transformed_fails_when_non_copyable(
     points_non_copyable : Union[Points, PointsNonCopyable],
     transform : RigidTransform,
-):
+) -> None:
     '''Test that rigid transformation are correctly applied out-of-place'''
     _ = points_non_copyable.rigidly_transformed(transform) # no asserts needed, since this line should fail
 
 def test_reset_transformed(
     points : Union[Points, PointsNonCopyable],
     transform : RigidTransform,
-):
+) -> None:
     '''Test that resetting a rigid transformation in-place return the object to its original state'''
     new_points = points.rigidly_transformed(transform)
     resetted_points = new_points.reset_transformed()
@@ -148,7 +152,7 @@ def test_reset_transformed(
 )
 def test_reset_transformed_fails_when_non_copyable(
         points_non_copyable : Union[Points, PointsNonCopyable],
-    ):
+    ) -> None:
     '''Test that rigid transformation are correctly applied out-of-place'''
     _ = points_non_copyable.reset_transformed() # no asserts needed, since this line should fail
 

--- a/mupt/tests/geometry/test_rigidly_transformable.py
+++ b/mupt/tests/geometry/test_rigidly_transformable.py
@@ -1,8 +1,5 @@
 '''Test that Protocol for RigidlyTransformable objects is implemented correctly'''
 
-__author__ = 'Timotej Bernat'
-__email__ = 'timotej.bernat@colorado.edu'
-
 import pytest
 from typing import Union
 from itertools import product as cartesian

--- a/mupt/tests/geometry/test_rigidly_transformable.py
+++ b/mupt/tests/geometry/test_rigidly_transformable.py
@@ -1,5 +1,8 @@
 '''Test that Protocol for RigidlyTransformable objects is implemented correctly'''
 
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
 import pytest
 from typing import Union
 from itertools import product as cartesian

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -3,11 +3,14 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-import pytest 
+import pytest
+from itertools import product as cartesian
 
 import numpy as np
+import numpy.testing as nptest
 from scipy.spatial.transform import Rotation, RigidTransform
 
+from mupt.geometry.transforms.rigid import random_rigid_transformation
 from mupt.geometry.shapes import (
     visualize_shape,
     BoundedShape,
@@ -24,18 +27,43 @@ def shapes() -> list[BoundedTransformableShape]:
     '''Sample instances of BoundedTransformableShapes to test on'''
     return [
         PointCloud(np.random.rand(40,3)),
-        Cylinder(1, 4),
-        Sphere(1),
+        Cylinder(1.2, 4),
+        Sphere(3.5),
         Ellipsoid.from_components(1, 1, 2),
     ]
 
-@pytest.mark.parametrize('shape', shapes())
-def test_volume(shape : BoundedShape) -> None:
-    ...
+def shapes_with_volumes() -> list[tuple[BoundedTransformableShape, float]]:
+    '''Collection of shapes with known volumes, returned as (shape, expected volume) pairs'''
+    return [
+        (PointCloud.cubic(2.0), 8),
+        (Cylinder(2, 4), 16*np.pi),
+        (Sphere(3.0), 36*np.pi),
+        (Ellipsoid.from_components(1, 2, 3), 8*np.pi),
+    ]
+
+@pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
+def test_volume(shape : BoundedShape, volume_expected : float) -> None:
+    '''Test that volume calculation is accurate'''
+    nptest.assert_allclose(shape.volume, volume_expected)
+
+@pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
+def test_volume_transformed(shape : BoundedTransformableShape, volume_expected : float) -> None:
+    '''Test that volume calculations remain invariant under rigid transformations'''
+    shape_transformed = shape.rigidly_transformed(random_rigid_transformation())
+    nptest.assert_allclose(shape_transformed.volume, volume_expected) # rigid motions have unit determinant and shouldn't affect volumes
 
 @pytest.mark.parametrize('shape', shapes())
 def test_scaling(shape : BoundedShape) -> None:
     ...
+
+@pytest.mark.parametrize('shape,scaling_factor', cartesian(shapes(), (0.5, 1.0, 2.0)))
+def test_volume_scaling(shape : BoundedShape, scaling_factor : float) -> None:
+    '''Test that computed volume of shapes changes as expected with scaling'''
+    v_orig : float = shape.volume
+    v_scaled : float = shape.scaled(scaling_factor).volume
+
+    nptest.assert_allclose(v_scaled / v_orig, scaling_factor**3)
+
 
 @pytest.mark.parametrize('shape', shapes())
 def test_containment(shape : BoundedShape) -> None:

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -1,0 +1,17 @@
+"""Unit tests for BoundedShape classes"""
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+import pytest 
+
+import numpy as np
+from scipy.spatial.transform import Rotation, RigidTransform
+
+from mupt.geometry.shapes import (
+    visualize_shape,
+    BoundedShape,
+    PointCloud,
+    Sphere,
+    Ellipsoid,
+)

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -75,14 +75,16 @@ def test_volume_scaling(shape : BoundedShape, scaling_factor : float) -> None:
 @pytest.mark.parametrize('shape', shapes_mixed())
 def test_containment_centroidal(shape : BoundedShape) -> None:
     '''Test that BoundedShapes contain their centroid''' 
-    # DEV TB: assumes shapes are convex - true at time of writing, but may need to revisit in the future
+    # DEV TB: assumes shapes are convex - true at time,
+    # of writing but may need to revisit in the future
     assert shape.contains(shape.centroid).all()
 
 # Transformable shape tests
-@pytest.mark.parametrize('shape', [])#shapes())
+@pytest.mark.parametrize('shape', shapes())
+# @pytest.mark.parametrize('shape', [])
 def test_equality(shape : BoundedTransformableShape) -> None:
     # NB: not checking direct equality with self, since that would be
-    # true even if no __eq__ was imlemented! (defaults to "is" behavior)
+    # true even if no __eq__ was implemented! (defaults to "is" behavior)
     assert shape.copy() == shape
 
 @pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -12,7 +12,6 @@ from scipy.spatial.transform import Rotation, RigidTransform
 
 from mupt.geometry.transforms.rigid import random_rigid_transformation
 from mupt.geometry.shapes import (
-    visualize_shape,
     BoundedShape,
     BoundedTransformableShape,
     PointCloud,

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -53,16 +53,11 @@ def shapes_with_volumes() -> list[tuple[BoundedTransformableShape, float]]:
     ]
 
 
+# "Pure" shape tests
 @pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
 def test_volume(shape : BoundedShape, volume_expected : float) -> None:
     '''Test that volume calculation is accurate'''
     nptest.assert_allclose(shape.volume, volume_expected)
-
-@pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
-def test_volume_transformed(shape : BoundedTransformableShape, volume_expected : float) -> None:
-    '''Test that volume calculations remain invariant under rigid transformations'''
-    shape_transformed = shape.rigidly_transformed(random_rigid_transformation())
-    nptest.assert_allclose(shape_transformed.volume, volume_expected) # rigid motions have unit determinant and shouldn't affect volumes
 
 @pytest.mark.parametrize('shape', shapes())
 def test_scaling(shape : BoundedShape) -> None:
@@ -82,6 +77,19 @@ def test_containment_centroidal(shape : BoundedShape) -> None:
     '''Test that BoundedShapes contain their centroid''' 
     # DEV TB: assumes shapes are convex - true at time of writing, but may need to revisit in the future
     assert shape.contains(shape.centroid).all()
+
+# Transformable shape tests
+@pytest.mark.parametrize('shape', [])#shapes())
+def test_equality(shape : BoundedTransformableShape) -> None:
+    # NB: not checking direct equality with self, since that would be
+    # true even if no __eq__ was imlemented! (defaults to "is" behavior)
+    assert shape.copy() == shape
+
+@pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
+def test_volume_transformed(shape : BoundedTransformableShape, volume_expected : float) -> None:
+    '''Test that volume calculations remain invariant under rigid transformations'''
+    shape_transformed = shape.rigidly_transformed(random_rigid_transformation())
+    nptest.assert_allclose(shape_transformed.volume, volume_expected) # rigid motions have unit determinant and shouldn't affect volumes
 
 @pytest.mark.parametrize(
     'shape,scaling_factor,all_inside',

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -151,19 +151,3 @@ def test_containment_scaled(
     # means either the scaled copy contains the original (if factor >1) or vice-versa (if <1)
     mesh_points, triangles = shape.scaled(scaling_factor).surface_mesh() # implicitly also tests surface_mesh() - convenient, but not very atomic
     assert np.all(shape.contains(mesh_points) == all_inside)
-
-@pytest.mark.parametrize(
-    'shape,transformation,shape_transformed_expected',
-    [],
-)
-def test_shape_rigidly_transformed(
-    shape : BoundedTransformableShape,
-    transformation : RigidTransform,
-    shape_transformed_expected : BoundedTransformableShape,
-) -> None:
-    '''Test thatout-of-place rigid transformations of shapes give the expected output shape'''
-    shape_init = shape.copy()
-    shape_transformed = shape.rigidly_transform(transformation)
-    
-    # ensure target output is attained AND that original is unmodified
-    assert (shape_transformed == shape_transformed_expected) and (shape == shape_init)

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -22,15 +22,26 @@ from mupt.geometry.shapes import (
 )
 
 
-# DEV: deliverately not a fixture, since iterated over in parametrize args
+# DEV: deliberately not a fixture, since iterated over in parametrize args
 def shapes() -> list[BoundedTransformableShape]: 
-    '''Sample instances of BoundedTransformableShapes to test on'''
+    '''Sample instances of untransformed BoundedTransformableShapes to test on'''
     return [
         PointCloud(np.random.rand(40,3)),
         Cylinder(1.2, 4),
         Sphere(3.5),
         Ellipsoid.from_components(1, 1, 2),
     ]
+
+def shapes_transformed() -> list[BoundedTransformableShape]:
+    '''Transformed versions of the sample test BoundedTransformableShape instances returned by `shapes()`'''
+    return [
+        shape.rigidly_transformed(random_rigid_transformation())
+            for shape in shapes()
+    ]
+
+def shapes_mixed() -> list[BoundedTransformableShape]:
+    '''Combined collection of transformed and untransformed example shapes'''
+    return [*shapes(), *shapes_transformed()]
 
 def shapes_with_volumes() -> list[tuple[BoundedTransformableShape, float]]:
     '''Collection of shapes with known volumes, returned as (shape, expected volume) pairs'''
@@ -40,6 +51,7 @@ def shapes_with_volumes() -> list[tuple[BoundedTransformableShape, float]]:
         (Sphere(3.0), 36*np.pi),
         (Ellipsoid.from_components(1, 2, 3), 8*np.pi),
     ]
+
 
 @pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
 def test_volume(shape : BoundedShape, volume_expected : float) -> None:
@@ -54,6 +66,7 @@ def test_volume_transformed(shape : BoundedTransformableShape, volume_expected :
 
 @pytest.mark.parametrize('shape', shapes())
 def test_scaling(shape : BoundedShape) -> None:
+    # TODO: implement BoundedShape.__eq__() (and on subtypes) to permit easy comparisons
     ...
 
 @pytest.mark.parametrize('shape,scaling_factor', cartesian(shapes(), (0.5, 1.0, 2.0)))
@@ -64,11 +77,47 @@ def test_volume_scaling(shape : BoundedShape, scaling_factor : float) -> None:
 
     nptest.assert_allclose(v_scaled / v_orig, scaling_factor**3)
 
+@pytest.mark.parametrize('shape', shapes_mixed())
+def test_containment_centroidal(shape : BoundedShape) -> None:
+    '''Test that BoundedShapes contain their centroid''' 
+    # DEV TB: assumes shapes are convex - true at time of writing, but may need to revisit in the future
+    assert shape.contains(shape.centroid).all()
 
-@pytest.mark.parametrize('shape', shapes())
-def test_containment(shape : BoundedShape) -> None:
-    ...
+@pytest.mark.parametrize(
+    'shape,scaling_factor,expected_contains',
+    [
+        (shape, scaling_factor, expected_contains)
+            for shape, (scaling_factor, expected_contains) in cartesian(
+                shapes_mixed(),
+                {
+                    0.25 : True,
+                    0.5  : True,
+                    2.0  : False,
+                    3.14 : False,
+                }.items(),
+            )
+    ],
+)
+def test_containment_scaled(
+    shape : BoundedTransformableShape,
+    scaling_factor : float,
+    expected_contains : bool, 
+) -> None:
+    '''Test containment checks on shapes, relative to dilated and compressed versions of themselves'''
+    # NB: in this SPECIFIC case, uniform scaling of convex shapes about center by non-unity scaling factor
+    # means either the scaled copy contains the original (if factor >1) or vice-versa (if <1)
+    mesh_points, triangles = shape.scaled(scaling_factor).surface_mesh() # implicitly also tests surface_mesh() - convenient, but not very atomic
+    print(shape.contains(mesh_points) == expected_contains)
+    assert np.all(shape.contains(mesh_points) == expected_contains)
 
-@pytest.mark.parametrize('shape', shapes())
-def test_rigid_transforms(shape : BoundedTransformableShape) -> None:
+@pytest.mark.parametrize(
+    'shape_init,transformation,shape_transformed_expected',
+    [],
+)
+def test_shape_rigidly_transformed(
+    shape_init : BoundedTransformableShape,
+    transformation : RigidTransform,
+    shape_transformed_expected : BoundedTransformableShape,
+) -> None:
+    '''Test thatout-of-place rigid transformations of shapes give the expected output shape'''
     ...

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -1,8 +1,5 @@
 """Unit tests for BoundedShape classes"""
 
-__author__ = 'Timotej Bernat'
-__email__ = 'timotej.bernat@colorado.edu'
-
 import pytest
 from itertools import product as cartesian
 

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -11,7 +11,22 @@ from scipy.spatial.transform import Rotation, RigidTransform
 from mupt.geometry.shapes import (
     visualize_shape,
     BoundedShape,
+    BoundedTransformableShape,
     PointCloud,
+    Cylinder,
     Sphere,
     Ellipsoid,
 )
+
+
+def test_volume(shape : BoundedShape) -> None:
+    ...
+
+def test_scaling(shape : BoundedShape) -> None:
+    ...
+
+def test_containment(shape : BoundedShape) -> None:
+    ...
+
+def test_rigid_transforms(shape : BoundedTransformableShape) -> None:
+    ...

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -55,6 +55,30 @@ def shapes_with_volumes() -> list[tuple[BoundedTransformableShape, float]]:
     
 
 # "Pure" shape tests
+@pytest.mark.parametrize(
+    'shape,other,expected_equal',
+    [
+        (PointCloud.cubic(2.0), PointCloud.cubic(2.0), True),
+        (PointCloud.cubic(2.0), PointCloud(np.random.rand(8,3)), False),
+        (Ellipsoid.from_components(1,2,3), Ellipsoid(radii=np.array([1.,2.,3.])), True),
+        (Sphere(radius=1), Sphere(radius=1.0), True),
+        (
+            Cylinder(1.5, length=2*np.sqrt(3), axial_direction=np.array([1,1,1])),
+            Cylinder.from_radius_and_axis(1.5, axis_vector=np.array([1,1,1])),
+            True,
+        ),
+        (Sphere(radius=1), Cylinder(1, 1), False),
+        (PointCloud.cubic(2.0), Sphere(3.14), False),
+    ]
+)
+def test_comparison(
+    shape : BoundedShape,
+    other : BoundedShape,
+    expected_equal : bool,
+) -> None:
+    '''Test that __eq__ is able to discern shape instances as expected'''
+    assert (shape == other) == expected_equal
+
 @pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
 def test_volume(shape : BoundedShape, volume_expected : float) -> None:
     '''Test that volume calculation is accurate'''
@@ -112,6 +136,7 @@ def test_containment_centroidal(shape : BoundedShape) -> None:
     # DEV TB: assumes shapes are convex - true at time,
     # of writing but may need to revisit in the future
     assert shape.contains(shape.centroid).all()
+
 
 # Transformable shape tests
 @pytest.mark.parametrize('shape', shapes())

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -34,7 +34,7 @@ def shapes() -> list[BoundedTransformableShape]:
 def shapes_transformed() -> list[BoundedTransformableShape]:
     '''Transformed versions of the sample test BoundedTransformableShape instances returned by `shapes()`'''
     return [
-        shape.rigidly_transformed(random_rigid_transformation())
+        shape.rigidly_transformed(random_rigid_transformation(translation_bound=1.0))
             for shape in shapes()
     ]
 
@@ -147,7 +147,7 @@ def test_equality(shape : BoundedTransformableShape) -> None:
 @pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
 def test_volume_transformed(shape : BoundedTransformableShape, volume_expected : float) -> None:
     '''Test that volume calculations remain invariant under rigid transformations'''
-    shape_transformed = shape.rigidly_transformed(random_rigid_transformation())
+    shape_transformed = shape.rigidly_transformed(random_rigid_transformation(translation_bound=1.0))
     nptest.assert_allclose(shape_transformed.volume, volume_expected) # rigid motions have unit determinant and shouldn't affect volumes
 
 @pytest.mark.parametrize(

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -84,10 +84,10 @@ def test_containment_centroidal(shape : BoundedShape) -> None:
     assert shape.contains(shape.centroid).all()
 
 @pytest.mark.parametrize(
-    'shape,scaling_factor,expected_contains',
+    'shape,scaling_factor,all_inside',
     [
-        (shape, scaling_factor, expected_contains)
-            for shape, (scaling_factor, expected_contains) in cartesian(
+        (shape, scaling_factor, all_inside)
+            for shape, (scaling_factor, all_inside) in cartesian(
                 shapes_mixed(),
                 {
                     0.25 : True,
@@ -101,23 +101,26 @@ def test_containment_centroidal(shape : BoundedShape) -> None:
 def test_containment_scaled(
     shape : BoundedTransformableShape,
     scaling_factor : float,
-    expected_contains : bool, 
+    all_inside : bool, 
 ) -> None:
     '''Test containment checks on shapes, relative to dilated and compressed versions of themselves'''
     # NB: in this SPECIFIC case, uniform scaling of convex shapes about center by non-unity scaling factor
     # means either the scaled copy contains the original (if factor >1) or vice-versa (if <1)
     mesh_points, triangles = shape.scaled(scaling_factor).surface_mesh() # implicitly also tests surface_mesh() - convenient, but not very atomic
-    print(shape.contains(mesh_points) == expected_contains)
-    assert np.all(shape.contains(mesh_points) == expected_contains)
+    assert np.all(shape.contains(mesh_points) == all_inside)
 
 @pytest.mark.parametrize(
-    'shape_init,transformation,shape_transformed_expected',
+    'shape,transformation,shape_transformed_expected',
     [],
 )
 def test_shape_rigidly_transformed(
-    shape_init : BoundedTransformableShape,
+    shape : BoundedTransformableShape,
     transformation : RigidTransform,
     shape_transformed_expected : BoundedTransformableShape,
 ) -> None:
     '''Test thatout-of-place rigid transformations of shapes give the expected output shape'''
-    ...
+    shape_init = shape.copy()
+    shape_transformed = shape.rigidly_transform(transformation)
+    
+    # ensure target output is attained AND that original is unmodified
+    assert (shape_transformed == shape_transformed_expected) and (shape == shape_init)

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -19,14 +19,28 @@ from mupt.geometry.shapes import (
 )
 
 
+# DEV: deliverately not a fixture, since iterated over in parametrize args
+def shapes() -> list[BoundedTransformableShape]: 
+    '''Sample instances of BoundedTransformableShapes to test on'''
+    return [
+        PointCloud(np.random.rand(40,3)),
+        Cylinder(1, 4),
+        Sphere(1),
+        Ellipsoid.from_components(1, 1, 2),
+    ]
+
+@pytest.mark.parametrize('shape', shapes())
 def test_volume(shape : BoundedShape) -> None:
     ...
 
+@pytest.mark.parametrize('shape', shapes())
 def test_scaling(shape : BoundedShape) -> None:
     ...
 
+@pytest.mark.parametrize('shape', shapes())
 def test_containment(shape : BoundedShape) -> None:
     ...
 
+@pytest.mark.parametrize('shape', shapes())
 def test_rigid_transforms(shape : BoundedTransformableShape) -> None:
     ...

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -43,15 +43,16 @@ def shapes_mixed() -> list[BoundedTransformableShape]:
     '''Combined collection of transformed and untransformed example shapes'''
     return [*shapes(), *shapes_transformed()]
 
-def shapes_with_volumes() -> list[tuple[BoundedTransformableShape, float]]:
+def shapes_with_volumes() -> list[tuple[BoundedTransformableShape, float]]: 
     '''Collection of shapes with known volumes, returned as (shape, expected volume) pairs'''
+    # DEV: only made function because multiple tests use these inputs
     return [
         (PointCloud.cubic(2.0), 8),
         (Cylinder(2, 4), 16*np.pi),
         (Sphere(3.0), 36*np.pi),
         (Ellipsoid.from_components(1, 2, 3), 8*np.pi),
     ]
-
+    
 
 # "Pure" shape tests
 @pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
@@ -59,10 +60,43 @@ def test_volume(shape : BoundedShape, volume_expected : float) -> None:
     '''Test that volume calculation is accurate'''
     nptest.assert_allclose(shape.volume, volume_expected)
 
-@pytest.mark.parametrize('shape', shapes())
-def test_scaling(shape : BoundedShape) -> None:
-    # TODO: implement BoundedShape.__eq__() (and on subtypes) to permit easy comparisons
-    ...
+@pytest.mark.parametrize(
+    'shape,scaling_factor,shape_scaled_expected',
+    [
+        (PointCloud.cubic(1), 0.5, PointCloud.cubic(0.5)),
+        (PointCloud.cubic(1), 3.0, PointCloud.cubic(3.0)),
+        (Sphere(1), 0.5, Sphere(0.5)),
+        (Sphere(1), 2.5, Sphere(2.5)),
+        (Ellipsoid.from_components(1, 2, 3), 2.0, Ellipsoid.from_components(2, 4, 6)),
+        (
+            Ellipsoid(
+                radii=np.array([4, 5, 6]),
+                center=np.array([1., 2., 1.,])
+            ),
+            0.25, 
+            Ellipsoid(
+                radii=np.array([1.0, 1.25, 1.5]),
+                center=np.array([1., 2., 1.,])
+            ),
+        ),
+        (Cylinder(3.14, length=0.58), 0.75, Cylinder(2.355, length=0.435)),
+        (
+            Cylinder.from_radius_and_axis(3.6, np.array([1, 1, 1])),
+            2.0,
+            Cylinder.from_radius_and_axis(7.2, np.array([2, 2, 2])),
+        ),
+    ]
+)    
+def test_scaling(
+    shape : BoundedShape,
+    scaling_factor : float,
+    shape_scaled_expected : BoundedShape,
+) -> None:
+    '''Test that scaling operations give the expected shape of the same type'''
+    # scaled in-place, both to test that this also works AND because the BoundedShape
+    # base does not implement .scaled() (only BoundedTranformableShape does this)
+    shape.scale(scaling_factor) 
+    assert shape == shape_scaled_expected
 
 @pytest.mark.parametrize('shape,scaling_factor', cartesian(shapes(), (0.5, 1.0, 2.0)))
 def test_volume_scaling(shape : BoundedShape, scaling_factor : float) -> None:
@@ -81,7 +115,6 @@ def test_containment_centroidal(shape : BoundedShape) -> None:
 
 # Transformable shape tests
 @pytest.mark.parametrize('shape', shapes())
-# @pytest.mark.parametrize('shape', [])
 def test_equality(shape : BoundedTransformableShape) -> None:
     # NB: not checking direct equality with self, since that would be
     # true even if no __eq__ was implemented! (defaults to "is" behavior)


### PR DESCRIPTION
## Description
This PR aims to improve consistency, usability, and feature completeness of the `mupt.geometry` module, especially as pertains to `BoundedShape`, as well as strengthening array-related typing.

Associated with the related [`better-shapes` branch of `mupt-examples`](https://github.com/MuPT-hub/mupt-examples/tree/better-shapes), which greatly simplifies and enhances the [mupt-shapes.ipynb example](https://github.com/MuPT-hub/mupt-examples/blob/better-shapes/examples_repr/mupt_shapes.ipynb)

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Resolve #10
  - [x] Standardize abstract interface for Shapes
    - [x] Provide uniform contract for surface_mesh() (in terms of a triangulated mesh)
    - [x] ~Implement support vector calculation~ Split off into #63 in the interest of time
    - [x] Implement comparisons between instances of each type of shape
    - [x] Implement uniform scaling interface
    - [x] Add `visualize()` interface with thin mpl wrapper
    - [x] Add Cylinder/Rod class
  - [x] Decouple BoundedShape from RigidlyTransformable
  - [x] Tighten up numpy-related typehints
  - [x] Fix non-updating visualization for PointCloud in `mupt-examples` 
  - [x] Write tests
    - [x] Containment 
    - [x] Volume
    - [x] Equality
    - [x] Scaling 
    - [x] Rigid transformations

## Questions
- [x] ~Should a NullShape class be implemented to avoid NoneType sentinels for unset `.shape` fields on Primitive?~
- [x] ~Is it worth adding support for arbitrary mapped labels to points in `PointCloud.positions`, rather than just int indices?~
_DEV: opting for no on both questions_

## Status
- [x] Address points in #10 
- [x] Update [mupt_shapes notebook](https://github.com/MuPT-hub/mupt-examples/blob/main/examples_repr/mupt_shapes.ipynb) in parallel examples repo
- [x] Ensure new tests pass
- [x] Pass review
- [x] Ready to go
  - [x] Close [examples #24](https://github.com/MuPT-hub/mupt-examples/pull/24) once merged