### PR TITLE
Refactor SAAMR topology traversal for MDAnalysis/RDKit exporters

### DIFF
--- a/mupt/interfaces/_shared/__init__.py
+++ b/mupt/interfaces/_shared/__init__.py
@@ -1,0 +1,4 @@
+"""Shared helpers for MuPT interface backends."""
+
+__author__ = "Joseph R. Laforet Jr."
+__email__ = "jola3134@colorado.edu"

--- a/mupt/interfaces/_shared/topology.py
+++ b/mupt/interfaces/_shared/topology.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 
 from ...chemistry.core import BOND_ORDER
 from ...mupr.embedding import ConnectorReference
-from ...mupr.primitives import Primitive, PrimitiveHandle
+from ...mupr.primitives import Primitive
 from ...roles import PrimitiveRole
 
 
@@ -187,14 +187,6 @@ def _pdb_resname(label: Hashable, resname_map: dict[str, str]) -> str:
 def connector_reference_sort_key(conn_ref: ConnectorReference) -> tuple[str, str]:
     """Return a deterministic key for connector refs with arbitrary hashable handles."""
     return (repr(conn_ref.primitive_handle), repr(conn_ref.connector_handle))
-
-
-def _child_handle(parent: Primitive, child: Primitive) -> PrimitiveHandle:
-    """Return the parent-local handle for a known child Primitive."""
-    for handle, candidate in parent.children_by_handle.items():
-        if candidate is child:
-            return handle
-    raise ValueError(f"Child '{child.label}' is not attached to parent '{parent.label}'")
 
 
 def _resolve_to_atom(

--- a/mupt/interfaces/_shared/topology.py
+++ b/mupt/interfaces/_shared/topology.py
@@ -1,0 +1,222 @@
+"""Shared topology traversal helpers for exporter interfaces."""
+
+__author__ = "Joseph R. Laforet Jr."
+__email__ = "jola3134@colorado.edu"
+
+from collections.abc import Hashable
+from dataclasses import dataclass, field
+
+from ...chemistry.core import BOND_ORDER
+from ...mupr.embedding import ConnectorReference
+from ...mupr.primitives import Primitive, PrimitiveHandle
+from ...roles import PrimitiveRole
+
+
+@dataclass
+class SAAMRRoleTopologyIndex:
+    """Role-indexed view of a SAAMR-like Primitive hierarchy."""
+
+    segments: list[Primitive] = field(default_factory=list)
+    residues_by_segment: dict[int, list[Primitive]] = field(default_factory=dict)
+    particles_by_residue: dict[int, list[Primitive]] = field(default_factory=dict)
+    segment_of_node: dict[int, Primitive] = field(default_factory=dict)
+    bond_nodes: list[Primitive] = field(default_factory=list)
+    bond_nodes_by_segment: dict[int, list[Primitive]] = field(default_factory=dict)
+
+
+def build_saamr_role_topology_index(root: Primitive) -> SAAMRRoleTopologyIndex:
+    """Build a single-pass role index for a SAAMR-like Primitive hierarchy.
+
+    The accepted hierarchy is role based rather than depth based: UNASSIGNED
+    grouping nodes may appear between canonical SAAMR roles, but SEGMENT and
+    RESIDUE roles cannot nest within the same role.
+    """
+    if root.role != PrimitiveRole.UNIVERSE:
+        raise ValueError(
+            "Root Primitive must have role=PrimitiveRole.UNIVERSE. "
+            "Assign roles via assign_SAAMR_roles() or set them manually."
+        )
+
+    index = SAAMRRoleTopologyIndex()
+
+    def visit(
+        node: Primitive,
+        current_segment: Primitive | None,
+        current_residue: Primitive | None,
+    ) -> None:
+        role = node.role
+
+        if role == PrimitiveRole.SEGMENT:
+            if current_segment is not None:
+                raise ValueError(
+                    f"SEGMENT '{current_segment.label}' contains nested SEGMENT(s) "
+                    f"['{node.label}']."
+                )
+            current_segment = node
+            index.segments.append(node)
+            index.residues_by_segment[id(node)] = []
+            index.bond_nodes_by_segment[id(node)] = []
+
+        elif role == PrimitiveRole.RESIDUE:
+            if current_residue is not None:
+                raise ValueError(
+                    f"RESIDUE '{current_residue.label}' contains nested RESIDUE(s) "
+                    f"['{node.label}']."
+                )
+            if current_segment is None:
+                raise ValueError("RESIDUE-role Primitives must be enclosed by a SEGMENT.")
+            current_residue = node
+            index.residues_by_segment[id(current_segment)].append(node)
+            index.particles_by_residue[id(node)] = []
+
+        elif role == PrimitiveRole.PARTICLE and not node.is_leaf:
+            raise ValueError("PARTICLE-role Primitives must be leaves.")
+
+        if node.internal_connections:
+            if current_segment is None:
+                raise ValueError(
+                    "SAAMR role-aware export does not support internal connections "
+                    "owned above a SEGMENT-role Primitive. Move the bond owner into "
+                    "a SEGMENT or represent the cross-segment relationship as external "
+                    "connectors."
+                )
+            index.bond_nodes.append(node)
+            index.bond_nodes_by_segment[id(current_segment)].append(node)
+
+        if current_segment is not None:
+            index.segment_of_node[id(node)] = current_segment
+
+        if node.is_leaf:
+            if role == PrimitiveRole.SEGMENT:
+                raise ValueError(
+                    f"SEGMENT-role Primitive '{node.label}' contains no RESIDUE-role descendants."
+                )
+            if role == PrimitiveRole.RESIDUE:
+                raise ValueError(
+                    f"RESIDUE-role Primitive '{node.label}' contains no PARTICLE leaves."
+                )
+            if role != PrimitiveRole.PARTICLE:
+                raise ValueError("All leaves must have role=PrimitiveRole.PARTICLE.")
+            if node.element is None:
+                raise ValueError(
+                    f"Leaf Primitive '{node}' has role=PARTICLE but no element assigned. "
+                    "All-atom export requires atomic PARTICLE leaves."
+                )
+            if current_segment is None or current_residue is None:
+                raise ValueError(
+                    "PARTICLE leaves must be enclosed by RESIDUE and SEGMENT roles."
+                )
+            index.particles_by_residue[id(current_residue)].append(node)
+            return
+
+        for child in node.children:
+            visit(child, current_segment, current_residue)
+
+    visit(root, current_segment=None, current_residue=None)
+
+    if not index.segments:
+        raise ValueError("No SEGMENT-role Primitives found in hierarchy.")
+    if not index.particles_by_residue:
+        raise ValueError("No RESIDUE-role Primitives found in hierarchy.")
+    for segment in index.segments:
+        residues = index.residues_by_segment[id(segment)]
+        if not residues:
+            raise ValueError(
+                f"SEGMENT-role Primitive '{segment.label}' contains no RESIDUE-role descendants."
+            )
+        empty_residues = [
+            residue.label
+            for residue in residues
+            if not index.particles_by_residue[id(residue)]
+        ]
+        if empty_residues:
+            raise ValueError(
+                f"SEGMENT-role Primitive '{segment.label}' contains RESIDUE-role "
+                f"Primitive(s) with no PARTICLE leaves: {empty_residues}."
+            )
+
+    return index
+
+
+def _pdb_resname(label: Hashable, resname_map: dict[str, str]) -> str:
+    """Map a residue label to a PDB-compliant 3-character residue name."""
+    label = str(label)
+    if resname_map and label in resname_map:
+        name = resname_map[label]
+    else:
+        name = label
+
+    if len(name) != 3:
+        raise ValueError(f"Residue name '{name}' (from '{label}') is not 3 characters long")
+    return name.upper()
+
+
+def connector_reference_sort_key(conn_ref: ConnectorReference) -> tuple[str, str]:
+    """Return a deterministic key for connector refs with arbitrary hashable handles."""
+    return (repr(conn_ref.primitive_handle), repr(conn_ref.connector_handle))
+
+
+def _child_handle(parent: Primitive, child: Primitive) -> PrimitiveHandle:
+    """Return the parent-local handle for a known child Primitive."""
+    for handle, candidate in parent.children_by_handle.items():
+        if candidate is child:
+            return handle
+    raise ValueError(f"Child '{child.label}' is not attached to parent '{parent.label}'")
+
+
+def _resolve_to_atom(
+    parent: Primitive,
+    conn_ref: ConnectorReference,
+    _depth: int = 0,
+    _max_depth: int = 50,
+) -> Primitive:
+    """Recursively follow external connectors to find the leaf atom."""
+    if _depth > _max_depth:
+        raise ValueError(
+            f"_resolve_to_atom exceeded maximum recursion depth ({_max_depth}) "
+            f"starting from parent '{parent.label}' at connector "
+            f"({conn_ref.primitive_handle}, {conn_ref.connector_handle}). "
+            "This indicates non-terminating connector resolution, likely caused by "
+            "malformed hierarchy or connector references."
+        )
+
+    try:
+        child = parent.fetch_child(conn_ref.primitive_handle)
+    except (KeyError, AttributeError) as exc:
+        raise ValueError(
+            f"Cannot resolve atom: child '{conn_ref.primitive_handle}' "
+            f"not found under parent '{parent.label}'."
+        ) from exc
+
+    if child.is_atom:
+        return child
+
+    try:
+        next_ref = child.external_connectors[conn_ref.connector_handle]
+    except KeyError as exc:
+        raise ValueError(
+            f"Cannot resolve atom: external connector "
+            f"'{conn_ref.connector_handle}' not found on child "
+            f"'{child.label}' (parent '{parent.label}'). "
+            "Ensure the primitive tree has well-formed connector chains."
+        ) from exc
+
+    return _resolve_to_atom(child, next_ref, _depth=_depth + 1, _max_depth=_max_depth)
+
+
+def resolve_to_atom_cached(
+    parent: Primitive,
+    conn_ref: ConnectorReference,
+    cache: dict[tuple[int, object, object], Primitive],
+) -> Primitive:
+    """Resolve a connector reference to an atom using a caller-owned cache."""
+    cache_key = (id(parent), conn_ref.primitive_handle, conn_ref.connector_handle)
+    if cache_key not in cache:
+        cache[cache_key] = _resolve_to_atom(parent, conn_ref)
+    return cache[cache_key]
+
+
+def _bond_order_from_conn_ref(parent: Primitive, conn_ref: ConnectorReference) -> float:
+    """Infer numeric bond order from a connection reference."""
+    connector = parent.fetch_connector_on_child(conn_ref)
+    return BOND_ORDER[connector.bondtype]

--- a/mupt/interfaces/_shared/topology.py
+++ b/mupt/interfaces/_shared/topology.py
@@ -3,7 +3,7 @@
 __author__ = "Joseph R. Laforet Jr."
 __email__ = "jola3134@colorado.edu"
 
-from collections.abc import Hashable
+from collections.abc import Hashable, Iterator
 from dataclasses import dataclass, field
 
 from ...chemistry.core import BOND_ORDER
@@ -22,6 +22,18 @@ class SAAMRRoleTopologyIndex:
     segment_of_node: dict[int, Primitive] = field(default_factory=dict)
     bond_nodes: list[Primitive] = field(default_factory=list)
     bond_nodes_by_segment: dict[int, list[Primitive]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SAAMRResidueRecord:
+    """One RESIDUE-role node and its role-aware traversal context."""
+
+    segment_idx: int
+    segment: Primitive
+    residue_idx: int
+    residue_global_idx: int
+    residue: Primitive
+    particles: tuple[Primitive, ...]
 
 
 def build_saamr_role_topology_index(root: Primitive) -> SAAMRRoleTopologyIndex:
@@ -136,6 +148,27 @@ def build_saamr_role_topology_index(root: Primitive) -> SAAMRRoleTopologyIndex:
             )
 
     return index
+
+
+def iter_saamr_residue_records(
+    index: SAAMRRoleTopologyIndex,
+) -> Iterator[SAAMRResidueRecord]:
+    """Yield RESIDUE-role records in deterministic SAAMR traversal order."""
+    residue_global_idx = 0
+    for segment_idx, segment in enumerate(index.segments):
+        for residue_idx, residue in enumerate(
+            index.residues_by_segment[id(segment)],
+            start=1,
+        ):
+            yield SAAMRResidueRecord(
+                segment_idx=segment_idx,
+                segment=segment,
+                residue_idx=residue_idx,
+                residue_global_idx=residue_global_idx,
+                residue=residue,
+                particles=tuple(index.particles_by_residue[id(residue)]),
+            )
+            residue_global_idx += 1
 
 
 def _pdb_resname(label: Hashable, resname_map: dict[str, str]) -> str:

--- a/mupt/interfaces/mdanalysis/strategies.py
+++ b/mupt/interfaces/mdanalysis/strategies.py
@@ -5,126 +5,18 @@ __email__ = "jola3134@colorado.edu"
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from collections.abc import Hashable
 from typing import Optional
 
-from anytree import PreOrderIter
 import numpy as np
 
-from ...chemistry.core import BOND_ORDER
-from ...mupr.embedding import ConnectorReference
 from ...mupr.primitives import Primitive
-from ...roles import PrimitiveRole
-
-
-def _pdb_resname(label: Hashable, resname_map: dict[str, str]) -> str:
-    """Map a residue label to a PDB-compliant 3-character residue name.
-
-    Parameters
-    ----------
-    label : Hashable
-        Original residue label from the Primitive object.  Non-string
-        labels are normalized to ``str(label)`` before lookup and
-        length validation.
-    resname_map : dict[str, str]
-        Mapping from residue labels to 3-character PDB residue names.
-
-    Returns
-    -------
-    str
-        Uppercase, 3-character PDB-compliant residue name.
-
-    Raises
-    ------
-    ValueError
-        If the resulting residue name is not exactly 3 characters long.
-    """
-    label = str(label)
-    if resname_map and label in resname_map:
-        name = resname_map[label]
-    else:
-        name = label
-
-    if len(name) != 3:
-        raise ValueError(f"Residue name '{name}' (from '{label}') is not 3 characters long")
-    return name.upper()
-
-
-def _resolve_to_atom(
-    parent: Primitive,
-    conn_ref: ConnectorReference,
-    _depth: int = 0,
-    _max_depth: int = 50,
-) -> Primitive:
-    """Recursively follow external_connectors to find the leaf atom.
-
-    Raises
-    ------
-    ValueError
-        If the connector chain is broken (missing child or external
-        connector entry) or if recursion exceeds *_max_depth*, which
-        indicates non-terminating connector resolution, typically caused
-        by malformed hierarchy or connector references.
-    """
-    if _depth > _max_depth:
-        raise ValueError(
-            f"_resolve_to_atom exceeded maximum recursion depth ({_max_depth}) "
-            f"starting from parent '{parent.label}' at connector "
-            f"({conn_ref.primitive_handle}, {conn_ref.connector_handle}). "
-            "This indicates non-terminating connector resolution, likely caused by "
-            "malformed hierarchy or connector references."
-        )
-
-    try:
-        child = parent.fetch_child(conn_ref.primitive_handle)
-    except (KeyError, AttributeError) as exc:
-        raise ValueError(
-            f"Cannot resolve atom: child '{conn_ref.primitive_handle}' "
-            f"not found under parent '{parent.label}'."
-        ) from exc
-
-    if child.is_atom:
-        return child
-
-    try:
-        next_ref = child.external_connectors[conn_ref.connector_handle]
-    except KeyError as exc:
-        raise ValueError(
-            f"Cannot resolve atom: external connector "
-            f"'{conn_ref.connector_handle}' not found on child "
-            f"'{child.label}' (parent '{parent.label}'). "
-            "Ensure the primitive tree has well-formed connector chains."
-        ) from exc
-
-    return _resolve_to_atom(child, next_ref, _depth=_depth + 1, _max_depth=_max_depth)
-
-
-def _bond_order_from_conn_ref(parent: Primitive, conn_ref: ConnectorReference) -> float:
-    """Infer bond order from a connection reference at the current parent level.
-
-    Parameters
-    ----------
-    parent : Primitive
-        The parent node whose ``internal_connections`` contain *conn_ref*.
-    conn_ref : ConnectorReference
-        Reference to the child primitive and its connector handle.
-
-    Returns
-    -------
-    float
-        Numeric bond order derived from the connector's bondtype.
-
-    Raises
-    ------
-    MissingConnectorError
-        If the referenced connector does not exist on the child primitive.
-        This indicates a corrupted primitive tree (connectors are always
-        present for valid internal connections).
-    KeyError
-        If the connector's bondtype is not in the BOND_ORDER lookup table.
-    """
-    connector = parent.fetch_connector_on_child(conn_ref)
-    return BOND_ORDER[connector.bondtype]
+from .._shared.topology import (
+    _bond_order_from_conn_ref,
+    _pdb_resname,
+    build_saamr_role_topology_index,
+    connector_reference_sort_key,
+    resolve_to_atom_cached,
+)
 
 
 @dataclass
@@ -168,8 +60,8 @@ class AllAtomExportStrategy(MDAExportStrategy):
     Although only the four SAAMR roles are recognized (UNIVERSE,
     SEGMENT, RESIDUE, PARTICLE), this strategy supports trees of arbitrary
     depth. Intermediate nodes between role-tagged levels (e.g., a "domain"
-    grouping between UNIVERSE and SEGMENT) are traversed transparently via
-    ``PreOrderIter`` and carry ``PrimitiveRole.UNASSIGNED``.
+    grouping between UNIVERSE and SEGMENT) are traversed transparently by the
+    shared SAAMR role index and carry ``PrimitiveRole.UNASSIGNED``.
     """
 
     def __init__(
@@ -190,148 +82,64 @@ class AllAtomExportStrategy(MDAExportStrategy):
         return "All-atom"
 
     def validate(self, root: Primitive) -> None:
-        """Validate role assignments needed for all-atom export.
-
-        Checks performed:
-        - Root must have UNIVERSE role
-        - At least one SEGMENT and one RESIDUE must exist
-        - All leaves must have PARTICLE role
-        - No SEGMENT may contain a descendant SEGMENT (nesting forbidden)
-        - No RESIDUE may contain a descendant RESIDUE (nesting forbidden)
-        """
-        if root.role != PrimitiveRole.UNIVERSE:
-            raise ValueError(
-                "Root Primitive must have role=PrimitiveRole.UNIVERSE. "
-                "(Unassigned nodes default to PrimitiveRole.UNASSIGNED.) "
-                "Assign roles via assign_SAAMR_roles() or set them manually."
-            )
-
-        segment_nodes = [node for node in PreOrderIter(root) if node.role == PrimitiveRole.SEGMENT]
-        residue_nodes = [node for node in PreOrderIter(root) if node.role == PrimitiveRole.RESIDUE]
-        if not segment_nodes:
-            raise ValueError(
-                "No SEGMENT-role Primitives found in hierarchy. "
-                "Assign roles via assign_SAAMR_roles() or set them manually."
-            )
-        if not residue_nodes:
-            raise ValueError(
-                "No RESIDUE-role Primitives found in hierarchy. "
-                "Assign roles via assign_SAAMR_roles() or set them manually."
-            )
-
-        for leaf in root.leaves:
-            if leaf.role != PrimitiveRole.PARTICLE:
-                raise ValueError(
-                    "All leaves must have role=PrimitiveRole.PARTICLE. "
-                    "Assign roles via assign_SAAMR_roles() or set them manually."
-                )
-
-        # Reject nested same-role nodes that would cause double-counting
-        for seg in segment_nodes:
-            nested_segs = [
-                node for node in PreOrderIter(seg)
-                if node.role == PrimitiveRole.SEGMENT and node is not seg
-            ]
-            if nested_segs:
-                raise ValueError(
-                    f"SEGMENT '{seg.label}' contains nested SEGMENT(s) "
-                    f"{[n.label for n in nested_segs]}. "
-                    "Nested SEGMENT roles are not allowed — each SEGMENT must "
-                    "define a non-overlapping partition of the hierarchy."
-                )
-
-        for res in residue_nodes:
-            nested_res = [
-                node for node in PreOrderIter(res)
-                if node.role == PrimitiveRole.RESIDUE and node is not res
-            ]
-            if nested_res:
-                raise ValueError(
-                    f"RESIDUE '{res.label}' contains nested RESIDUE(s) "
-                    f"{[n.label for n in nested_res]}. "
-                    "Nested RESIDUE roles are not allowed — each RESIDUE must "
-                    "define a non-overlapping partition of its parent SEGMENT."
-                )
+        """Validate role assignments needed for all-atom export."""
+        build_saamr_role_topology_index(root)
 
     def collect_topology(self, root: Primitive, resname_map: dict[str, str]) -> MDATopologyData:
-        """Walk the hierarchy and gather MDAnalysis topology arrays/lists."""
-        self.validate(root)
+        """Walk the hierarchy once and gather MDAnalysis topology arrays/lists."""
+        index = build_saamr_role_topology_index(root)
         data = MDATopologyData()
 
-        # Build global atom index from DFS pre-order leaf traversal
-        leaves = list(root.leaves)
-        n_atoms = len(leaves)
-        atom_id_to_global: dict[int, int] = {id(atom): idx for idx, atom in enumerate(leaves)}
+        particles = [
+            atom
+            for segment in index.segments
+            for residue in index.residues_by_segment[id(segment)]
+            for atom in index.particles_by_residue[id(residue)]
+        ]
+        n_atoms = len(particles)
+        atom_id_to_global: dict[int, int] = {
+            id(atom): idx for idx, atom in enumerate(particles)
+        }
 
-        # Pre-allocate resindex/segindex arrays so we can write by global index
         data.atom_resindex = [0] * n_atoms
         data.atom_segindex = [0] * n_atoms
 
-        # Collect per-atom data in DFS leaf order
-        for atom in leaves:
-            if atom.element is None:
-                raise ValueError(
-                    f"Leaf Primitive '{atom}' has role=PARTICLE but no element assigned. "
-                    "AllAtomExportStrategy requires atomic PARTICLE leaves."
-                )
+        for atom in particles:
             atom_symbol = atom.element.symbol
             data.atom_elements.append(atom_symbol)
             data.atom_names.append(atom_symbol)
 
-            if hasattr(atom, "shape") and atom.shape is not None:
+            if atom.shape is not None:
                 data.atom_positions.append(list(atom.shape.centroid))
             else:
                 data.atom_positions.append(list(self.default_atom_position))
 
-        # Walk segment -> residue -> particle to build hierarchy mapping
-        # Use PreOrderIter to find SEGMENT nodes at any depth (not just direct children)
-        segment_nodes = [node for node in PreOrderIter(root) if node.role == PrimitiveRole.SEGMENT]
-        data.num_segments = len(segment_nodes)
-        mapped_count = 0
-
-        for seg_idx, segment in enumerate(segment_nodes):
-            resid_counter = 1
-            residue_nodes = [node for node in PreOrderIter(segment) if node.role == PrimitiveRole.RESIDUE]
-
-            for residue in residue_nodes:
+        data.num_segments = len(index.segments)
+        for seg_idx, segment in enumerate(index.segments):
+            for resid_counter, residue in enumerate(
+                index.residues_by_segment[id(segment)],
+                start=1,
+            ):
                 data.residue_names.append(_pdb_resname(residue.label, resname_map))
                 data.residue_segindex.append(seg_idx)
                 data.residue_ids.append(resid_counter)
 
                 res_global_idx = len(data.residue_names) - 1
-                particle_leaves = [
-                    node
-                    for node in PreOrderIter(residue)
-                    if node.is_leaf and node.role == PrimitiveRole.PARTICLE
-                ]
-                for atom in particle_leaves:
+                for atom in index.particles_by_residue[id(residue)]:
                     atom_global_idx = atom_id_to_global[id(atom)]
                     data.atom_resindex[atom_global_idx] = res_global_idx
                     data.atom_segindex[atom_global_idx] = seg_idx
-                    mapped_count += 1
 
-                resid_counter += 1
-
-        if mapped_count != n_atoms:
-            raise ValueError(
-                f"Role hierarchy traversal mapped {mapped_count} of {n_atoms} PARTICLE leaves "
-                "to a RESIDUE and SEGMENT. Assign roles via assign_SAAMR_roles() or set them manually."
-            )
-
-        for node in PreOrderIter(root):
-            if node.is_leaf or not node.internal_connections:
-                continue
-
+        endpoint_cache: dict[tuple[int, object, object], Primitive] = {}
+        for node in index.bond_nodes:
             for conn_ref_pair in node.internal_connections:
-                # sort pair order for standardized bond-order reference
-                # frozenset iteration order is arbitrary, so we sort by handles
                 ref_list = sorted(
                     conn_ref_pair,
-                    key=lambda cr: (cr.primitive_handle, cr.connector_handle),
+                    key=connector_reference_sort_key,
                 )
                 conn_ref1, conn_ref2 = ref_list
-                atom1 = _resolve_to_atom(node, conn_ref1)
-                atom2 = _resolve_to_atom(node, conn_ref2)
+                atom1 = resolve_to_atom_cached(node, conn_ref1, endpoint_cache)
+                atom2 = resolve_to_atom_cached(node, conn_ref2, endpoint_cache)
 
                 idx1 = atom_id_to_global[id(atom1)]
                 idx2 = atom_id_to_global[id(atom2)]

--- a/mupt/interfaces/mdanalysis/strategies.py
+++ b/mupt/interfaces/mdanalysis/strategies.py
@@ -15,6 +15,7 @@ from .._shared.topology import (
     _pdb_resname,
     build_saamr_role_topology_index,
     connector_reference_sort_key,
+    iter_saamr_residue_records,
     resolve_to_atom_cached,
 )
 
@@ -89,12 +90,12 @@ class AllAtomExportStrategy(MDAExportStrategy):
         """Walk the hierarchy once and gather MDAnalysis topology arrays/lists."""
         index = build_saamr_role_topology_index(root)
         data = MDATopologyData()
+        residue_records = list(iter_saamr_residue_records(index))
 
         particles = [
             atom
-            for segment in index.segments
-            for residue in index.residues_by_segment[id(segment)]
-            for atom in index.particles_by_residue[id(residue)]
+            for residue_record in residue_records
+            for atom in residue_record.particles
         ]
         n_atoms = len(particles)
         atom_id_to_global: dict[int, int] = {
@@ -115,20 +116,15 @@ class AllAtomExportStrategy(MDAExportStrategy):
                 data.atom_positions.append(list(self.default_atom_position))
 
         data.num_segments = len(index.segments)
-        for seg_idx, segment in enumerate(index.segments):
-            for resid_counter, residue in enumerate(
-                index.residues_by_segment[id(segment)],
-                start=1,
-            ):
-                data.residue_names.append(_pdb_resname(residue.label, resname_map))
-                data.residue_segindex.append(seg_idx)
-                data.residue_ids.append(resid_counter)
+        for residue_record in residue_records:
+            data.residue_names.append(_pdb_resname(residue_record.residue.label, resname_map))
+            data.residue_segindex.append(residue_record.segment_idx)
+            data.residue_ids.append(residue_record.residue_idx)
 
-                res_global_idx = len(data.residue_names) - 1
-                for atom in index.particles_by_residue[id(residue)]:
-                    atom_global_idx = atom_id_to_global[id(atom)]
-                    data.atom_resindex[atom_global_idx] = res_global_idx
-                    data.atom_segindex[atom_global_idx] = seg_idx
+            for atom in residue_record.particles:
+                atom_global_idx = atom_id_to_global[id(atom)]
+                data.atom_resindex[atom_global_idx] = residue_record.residue_global_idx
+                data.atom_segindex[atom_global_idx] = residue_record.segment_idx
 
         endpoint_cache: dict[tuple[int, object, object], Primitive] = {}
         for node in index.bond_nodes:

--- a/mupt/tests/interfaces/test_shared_topology.py
+++ b/mupt/tests/interfaces/test_shared_topology.py
@@ -1,0 +1,56 @@
+"""Tests for shared SAAMR role topology traversal helpers."""
+
+import pytest
+
+from mupt.chemistry import ELEMENTS
+from mupt.interfaces._shared.topology import build_saamr_role_topology_index
+from mupt.mupr.primitives import Primitive
+from mupt.roles import PrimitiveRole
+
+
+def _particle(label: str) -> Primitive:
+    return Primitive(label=label, element=ELEMENTS[1], role=PrimitiveRole.PARTICLE)
+
+
+def test_build_saamr_role_topology_index_allows_unassigned_grouping_nodes():
+    universe = Primitive(label="universe", role=PrimitiveRole.UNIVERSE)
+    group = Primitive(label="group")
+    segment = Primitive(label="segment", role=PrimitiveRole.SEGMENT)
+    residue = Primitive(label="residue", role=PrimitiveRole.RESIDUE)
+    atom = _particle("H")
+
+    universe.attach_child(group)
+    group.attach_child(segment)
+    segment.attach_child(residue)
+    residue.attach_child(atom)
+
+    index = build_saamr_role_topology_index(universe)
+
+    assert index.segments == [segment]
+    assert index.residues_by_segment[id(segment)] == [residue]
+    assert index.particles_by_residue[id(residue)] == [atom]
+    assert index.segment_of_node[id(atom)] is segment
+
+
+def test_build_saamr_role_topology_index_rejects_empty_segment():
+    universe = Primitive(label="universe", role=PrimitiveRole.UNIVERSE)
+    universe.attach_child(Primitive(label="empty", role=PrimitiveRole.SEGMENT))
+
+    with pytest.raises(ValueError, match="contains no RESIDUE"):
+        build_saamr_role_topology_index(universe)
+
+
+def test_build_saamr_role_topology_index_rejects_nested_residue():
+    universe = Primitive(label="universe", role=PrimitiveRole.UNIVERSE)
+    segment = Primitive(label="segment", role=PrimitiveRole.SEGMENT)
+    residue = Primitive(label="residue", role=PrimitiveRole.RESIDUE)
+    nested = Primitive(label="nested", role=PrimitiveRole.RESIDUE)
+    atom = _particle("H")
+
+    universe.attach_child(segment)
+    segment.attach_child(residue)
+    residue.attach_child(nested)
+    nested.attach_child(atom)
+
+    with pytest.raises(ValueError, match="nested RESIDUE"):
+        build_saamr_role_topology_index(universe)

--- a/mupt/tests/interfaces/test_shared_topology.py
+++ b/mupt/tests/interfaces/test_shared_topology.py
@@ -1,5 +1,8 @@
 """Tests for shared SAAMR role topology traversal helpers."""
 
+__author__ = "Joseph R. Laforet Jr."
+__email__ = "jola3134@colorado.edu"
+
 import pytest
 
 from mupt.chemistry import ELEMENTS


### PR DESCRIPTION
## Summary
- Adds shared SAAMR role topology traversal helpers under `mupt.interfaces._shared`.
- Refactors MDAnalysis all-atom export to use the shared indexed traversal.
- The [previous implementation](https://github.com/MuPT-hub/mupt/blob/main/mupt/interfaces/mdanalysis/strategies.py#L222-L245) called DFS traversal multiple times for each "role-level". Rather than run DFS more than once, we instead populate a [dataclass ](https://github.com/MuPT-hub/mupt/blob/issue-51/shared-saamr-topology-index/mupt/interfaces/_shared/topology.py#L15-L24) to hold the information about node data corresponding to the different roles as we iterate. This means we only call [DFS once per tree](https://github.com/MuPT-hub/mupt/blob/issue-51/shared-saamr-topology-index/mupt/interfaces/_shared/topology.py#L39-L150).
- Adds shared-topology tests.

## Stack Position
This is PR 1 of 3 in the role-aware RDKit/SDF export stack.

Stack:
1. This PR: shared SAAMR topology traversal.
2. #59: role-aware RDKit Mol export.
3. #60: export-only `mupt.muptio.sdf` writer.

## After This Merges
After merging this PR into `main`:
- Retarget #59 from base `issue-51/shared-saamr-topology-index` to base `main`.
- Do not rebase #59 unless GitHub reports conflicts.
- If conflicts appear, merge updated `main` into #59's branch, resolve, and push.

## Verification
- `python -m pytest mupt/tests/interfaces/test_shared_topology.py -q`
- `python -m pytest mupt/tests/interfaces/mdanalysis/test_exporters.py -q`