### PR TITLE
Connector extension

### DIFF
--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -32,7 +32,7 @@ Shape = tuple
 DType = TypeVar('DType', bound=np.dtype)
 
 ## types accepted by 'order' arg of np.linalg.norm()
-OrderType = Optional[Union[int, Literal['fro'], Literal['nuc']]] 
+OrderType = Optional[Union[int, float, Literal['fro'], Literal['nuc']]] 
 
 ## Typehints for indeterminate size of a given array dimension
 M = TypeVar('M', bound=int) 

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -9,12 +9,13 @@ from typing import (
     TypeVar,
     Union,
 )
-S = TypeVar('S') # pure generics
-T = TypeVar('T') # pure generics
+# pure generics
+S = TypeVar('S')
+T = TypeVar('T')
 
 import numpy as np
 import numpy.typing as npt
-from numbers import Number, Real
+from numbers import Number#, Real
 
 
 # Numeric typehints
@@ -30,6 +31,9 @@ BoolNP = TypeVar('BoolNP', bound=np.dtype[np.bool_])
 Shape = tuple
 DType = TypeVar('DType', bound=np.dtype)
 
+## types accepted by 'order' arg of np.linalg.norm()
+OrderType = Optional[Union[int, Literal['fro'], Literal['nuc']]] 
+
 ## Typehints for indeterminate size of a given array dimension
 M = TypeVar('M', bound=int) 
 N = TypeVar('N', bound=int)
@@ -38,7 +42,7 @@ Dims = TypeVar('Dims', bound=int) # intended to typehint the number of dimension
 DimsPlus = TypeVar('DimsPlus', bound=int) # intended to typehint the number of dimensions +1 (no easy way to do arithmetic to generic types yet)
 
 # Fixed-size vector and array type annotations - consider deprecating, since they're not currently being used anywhere
-## DEV: this type of hard-coding sucks, but is the best we can do with the current Python type system
+## TB DEV: this type of hard-coding sucks, but is the best we can do with the current Python type system
 Vector2  = np.ndarray[Shape[Literal[2]], NumericNP]
 Vector3  = np.ndarray[Shape[Literal[3]], NumericNP]
 Vector4  = np.ndarray[Shape[Literal[4]], NumericNP]

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -6,6 +6,7 @@ __email__ = 'timotej.bernat@colorado.edu'
 from typing import (
     Literal,
     Optional,
+    Sequence,
     TypeVar,
     Union,
 )
@@ -71,8 +72,8 @@ BitVectorN = np.ndarray[Shape[N], BoolNP]
 
 # vector comparison
 def as_n_vector(
-    vectorlike : VectorN | Array1xN | ArrayNx1,
-    dimension : int=3,
+    vectorlike : VectorN | Array1xN | ArrayNx1 | Sequence[NumberLike],
+    dimension : Optional[int]=None,
     dtype : Optional[npt.DTypeLike]=None,
 ) -> VectorN:
     '''
@@ -81,11 +82,13 @@ def as_n_vector(
     
     Enables permissive ingestion of vector-shaped objects
     '''
-    if not isinstance(vectorlike, np.ndarray): # TODO: include support for list/tuple-like WITHOUT including sets, str, etc
-        raise TypeError(f'Vectorlike must be a numpy array, not {type(vectorlike)}')
+    # N.B.: strings and byte-like are TECHNICALLY also Sequences, but not the kind we want here
+    if isinstance(vectorlike, (str, bytes)) \
+        or (not isinstance(vectorlike, (np.ndarray, Sequence))):
+        raise TypeError(f'Vectorlike must be a numpy array of Sequence of Numerics, not {type(vectorlike).__name__}')
     
     vector_column = np.atleast_2d(vectorlike).reshape(-1) # permits transposed and nested vector inputs
-    if vector_column.shape != (dimension,):
+    if (dimension is not None) and (vector_column.shape != (dimension,)):
         raise ValueError(
             f'Expected vector with shape {(dimension,)}, got {vector_column.shape}'
         )
@@ -94,21 +97,3 @@ def as_n_vector(
         vector_column = vector_column.astype(dtype)
         
     return vector_column
-
-def compare_optional_positions(
-    position_1 : Optional[VectorN],
-    position_2 : Optional[VectorN],
-    **kwargs,
-) -> bool:
-    '''Check that two positional values are either 1) both undefined, or 2) both defined and equal'''
-    # DEV: replace with monadic interface down the line ("Maybe" pattern?)
-    if type(position_1) != type(position_2):
-        return False
-    
-    if position_1 is None: # both are None
-        return True
-    elif isinstance(position_1, np.ndarray):
-        return np.allclose(position_1, position_2, **kwargs)
-    else:
-        raise TypeError(f'Expected positions to be either None or numpy.ndarray, got {type(position_1)} and {type(position_2)}')
-    

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -82,7 +82,9 @@ def as_n_vector(
     
     Enables permissive ingestion of vector-shaped objects
     '''
-    if not isinstance(vectorlike, (np.ndarray, Sequence)): # TODO: include support for list/tuple-like WITHOUT including sets, str, etc
+    # N.B.: strins and byte-like are TECHNICALLY also Sequences, but not the kind we want here
+    if isinstance(vectorlike, (str, bytes)) \
+        or (not isinstance(vectorlike, (np.ndarray, Sequence))):
         raise TypeError(f'Vectorlike must be a numpy array of Sequence of Numerics, not {type(vectorlike).__name__}')
     
     vector_column = np.atleast_2d(vectorlike).reshape(-1) # permits transposed and nested vector inputs

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -6,6 +6,7 @@ __email__ = 'timotej.bernat@colorado.edu'
 from typing import (
     Literal,
     Optional,
+    Sequence,
     TypeVar,
     Union,
 )
@@ -71,8 +72,8 @@ BitVectorN = np.ndarray[Shape[N], BoolNP]
 
 # vector comparison
 def as_n_vector(
-    vectorlike : VectorN | Array1xN | ArrayNx1,
-    dimension : int=3,
+    vectorlike : VectorN | Array1xN | ArrayNx1 | Sequence[NumberLike],
+    dimension : Optional[int]=None,
     dtype : Optional[npt.DTypeLike]=None,
 ) -> VectorN:
     '''
@@ -81,11 +82,11 @@ def as_n_vector(
     
     Enables permissive ingestion of vector-shaped objects
     '''
-    if not isinstance(vectorlike, np.ndarray): # TODO: include support for list/tuple-like WITHOUT including sets, str, etc
-        raise TypeError(f'Vectorlike must be a numpy array, not {type(vectorlike)}')
+    if not isinstance(vectorlike, (np.ndarray, Sequence)): # TODO: include support for list/tuple-like WITHOUT including sets, str, etc
+        raise TypeError(f'Vectorlike must be a numpy array of Sequence of Numerics, not {type(vectorlike).__name__}')
     
     vector_column = np.atleast_2d(vectorlike).reshape(-1) # permits transposed and nested vector inputs
-    if vector_column.shape != (dimension,):
+    if (dimension is not None) and (vector_column.shape != (dimension,)):
         raise ValueError(
             f'Expected vector with shape {(dimension,)}, got {vector_column.shape}'
         )

--- a/mupt/geometry/arraytypes.py
+++ b/mupt/geometry/arraytypes.py
@@ -90,21 +90,3 @@ def as_n_vector(
         vector_column = vector_column.astype(dtype)
         
     return vector_column
-
-def compare_optional_positions(
-    position_1 : Optional[VectorN],
-    position_2 : Optional[VectorN],
-    **kwargs,
-) -> bool:
-    '''Check that two positional values are either 1) both undefined, or 2) both defined and equal'''
-    # DEV: replace with monadic interface down the line ("Maybe" pattern?)
-    if type(position_1) != type(position_2):
-        return False
-    
-    if position_1 is None: # both are None
-        return True
-    elif isinstance(position_1, np.ndarray):
-        return np.allclose(position_1, position_2, **kwargs)
-    else:
-        raise TypeError(f'Expected positions to be either None or numpy.ndarray, got {type(position_1)} and {type(position_2)}')
-    

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -11,12 +11,12 @@ from .arraytypes import (
     Shape,
     NumericNP,
     VectorN,
-    ArrayNxN,
+    ArrayNxM,
 )
 
 
 def normalize(
-    vector : VectorN | ArrayNxN,
+    vector : VectorN | ArrayNxM,
     order : Optional[Union[int, float, str]]=None,
 ) -> None:
     '''Normalize a vector or array of vectors in-place'''

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -8,17 +8,17 @@ import numpy as np
 
 from .arraytypes import (
     N,
-    Shape,
     NumericNP,
+    OrderType,
+    Shape,
     VectorN,
     ArrayNxN,
 )
-OrderType = Union[int, float, str] # types accepted by 'order' arg of np.linalg.norm()
 
 
 def normalize(
     vector : VectorN | ArrayNxN,
-    order : Optional[OrderType]=None,
+    order : OrderType=None,
 ) -> None:
     '''Normalize a vector or array of vectors in-place'''
     norms = np.atleast_1d( # ensure shape is broadcastable, even for scalars
@@ -30,14 +30,15 @@ def normalize(
     vector /= norms
 
 def normalized(
-    vector : np.ndarray[Shape[N, ...], NumericNP], # DEV: using generic here to indicate return has same dtype
-    order  : Optional[OrderType]=None,
+    # DEV: using generic here to indicate return has same dtype
+    vector : np.ndarray[Shape[N, ...], NumericNP], 
+    order : OrderType=None,
 ) -> np.ndarray[Shape[N, ...], NumericNP]:
     '''
     Return a normalized copy of a vector or array of vectors;
     The array supplied to "vector" is unchanged
     '''
-    new_vector = np.copy(vector)  # preserve original vector
+    new_vector = np.copy(vector)
     normalize(new_vector, order=order)
 
     return new_vector
@@ -46,7 +47,7 @@ def compare_optional_positions(
     position_1 : Optional[VectorN],
     position_2 : Optional[VectorN],
     radius : float=1E-8,
-    order : Optional[OrderType]=None,
+    order : OrderType=None,
 ) -> bool:
     '''
     Check that two positional values are either:

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -8,16 +8,17 @@ import numpy as np
 
 from .arraytypes import (
     N,
-    Shape,
     NumericNP,
+    OrderType,
+    Shape,
     VectorN,
     ArrayNxM,
 )
 
 
 def normalize(
-    vector : VectorN | ArrayNxM,
-    order : Optional[Union[int, float, str]]=None,
+    vector : VectorN | ArrayNxN,
+    order : OrderType=None,
 ) -> None:
     '''Normalize a vector or array of vectors in-place'''
     norms = np.atleast_1d( # ensure shape is broadcastable, even for scalars
@@ -29,20 +30,24 @@ def normalize(
     vector /= norms
 
 def normalized(
-    vector : np.ndarray[Shape[N, ...], NumericNP], # DEV: using generic here to indicate return has same dtype
-    order  : Optional[Union[int, float, str]]=None,
+    # DEV: using generic here to indicate return has same dtype
+    vector : np.ndarray[Shape[N, ...], NumericNP], 
+    order : OrderType=None,
 ) -> np.ndarray[Shape[N, ...], NumericNP]:
-    '''Return a normalized copy of a vector or array of vectors;
-    The array supplied to "vector" is unchanged'''
-    new_vector = np.copy(vector)  # preserve original vector
+    '''
+    Return a normalized copy of a vector or array of vectors;
+    The array supplied to "vector" is unchanged
+    '''
+    new_vector = np.copy(vector)
     normalize(new_vector, order=order)
 
     return new_vector
 
-def within_ball(
-    position_1 : VectorN,
-    position_2 : VectorN,
-    radius : float=1E-6,
+def compare_optional_positions(
+    position_1 : Optional[VectorN],
+    position_2 : Optional[VectorN],
+    radius : float=1E-8,
+    order : OrderType=None,
 ) -> bool:
     '''Check that two vectors are within a certain absolute distance of one another'''
     # TODO: check vector shapes match

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -13,11 +13,12 @@ from .arraytypes import (
     VectorN,
     ArrayNxN,
 )
+OrderType = Union[int, float, str] # types accepted by 'order' arg of np.linalg.norm()
 
 
 def normalize(
     vector : VectorN | ArrayNxN,
-    order : Optional[Union[int, float, str]]=None,
+    order : Optional[OrderType]=None,
 ) -> None:
     '''Normalize a vector or array of vectors in-place'''
     norms = np.atleast_1d( # ensure shape is broadcastable, even for scalars
@@ -30,22 +31,45 @@ def normalize(
 
 def normalized(
     vector : np.ndarray[Shape[N, ...], NumericNP], # DEV: using generic here to indicate return has same dtype
-    order  : Optional[Union[int, float, str]]=None,
+    order  : Optional[OrderType]=None,
 ) -> np.ndarray[Shape[N, ...], NumericNP]:
-    '''Return a normalized copy of a vector or array of vectors;
-    The array supplied to "vector" is unchanged'''
+    '''
+    Return a normalized copy of a vector or array of vectors;
+    The array supplied to "vector" is unchanged
+    '''
     new_vector = np.copy(vector)  # preserve original vector
     normalize(new_vector, order=order)
 
     return new_vector
 
-def within_ball(
-    position_1 : VectorN,
-    position_2 : VectorN,
-    radius : float=1E-6,
+def compare_optional_positions(
+    position_1 : Optional[VectorN],
+    position_2 : Optional[VectorN],
+    radius : float=1E-8,
+    order : Optional[OrderType]=None,
 ) -> bool:
-    '''Check that two vectors are within a certain absolute distance of one another'''
-    # TODO: check vector shapes match
-    if not (isinstance(position_1, np.ndarray) and isinstance(position_2, np.ndarray)):
-        raise TypeError(f'Expected position attributes to be numpy.ndarray, got {type(position_1)} and {type(position_2)}')
-    return (np.linalg.norm(position_1 - position_2, ord=2, axis=-1) < radius).astype(object) # cast to Python bool
+    '''
+    Check that two positional values are either:
+    * Both undefined (returns True)
+    * Both defined AND within a set in distance in a given p-norm (returns True if both conditions are met)
+    * One defined and one undefined, in either order (returns False)
+    '''
+    if type(position_1) != type(position_2):
+        return False
+    
+    if position_1 is None: # both are None
+        return True
+    elif isinstance(position_1, np.ndarray):
+        return (
+            np.linalg.norm(
+                position_1 - position_2,
+                ord=order,
+                axis=-1,
+            ) < radius
+        ).astype(object) # cast to Python bool
+    else:
+        raise TypeError(
+            f'Expected positions to be either NoneType or numpy.ndarray: ' \
+            f'got {type(position_1).__name__} and {type(position_2).__name__}'
+        )
+    

--- a/mupt/geometry/measure.py
+++ b/mupt/geometry/measure.py
@@ -3,7 +3,7 @@
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-from typing import Optional, Union
+from typing import Optional
 import numpy as np
 
 from .arraytypes import (
@@ -17,7 +17,7 @@ from .arraytypes import (
 
 
 def normalize(
-    vector : VectorN | ArrayNxN,
+    vector : VectorN | ArrayNxM,
     order : OrderType=None,
 ) -> None:
     '''Normalize a vector or array of vectors in-place'''
@@ -49,8 +49,28 @@ def compare_optional_positions(
     radius : float=1E-8,
     order : OrderType=None,
 ) -> bool:
-    '''Check that two vectors are within a certain absolute distance of one another'''
-    # TODO: check vector shapes match
-    if not (isinstance(position_1, np.ndarray) and isinstance(position_2, np.ndarray)):
-        raise TypeError(f'Expected position attributes to be numpy.ndarray, got {type(position_1)} and {type(position_2)}')
-    return (np.linalg.norm(position_1 - position_2, ord=2, axis=-1) < radius).astype(object) # cast to Python bool
+    '''
+    Check that two positional values are either:
+    * Both undefined (returns True)
+    * Both defined AND within a set in distance in a given p-norm (returns True if both conditions are met)
+    * One defined and one undefined, in either order (returns False)
+    '''
+    if type(position_1) != type(position_2):
+        return False
+    
+    if position_1 is None: # both are None
+        return True
+    elif isinstance(position_1, np.ndarray):
+        return (
+            np.linalg.norm(
+                position_1 - position_2,
+                ord=order,
+                axis=-1,
+            ) < radius
+        ).astype(object) # cast to Python bool
+    else:
+        raise TypeError(
+            f'Expected positions to be either NoneType or numpy.ndarray: ' \
+            f'got {type(position_1).__name__} and {type(position_2).__name__}'
+        )
+    

--- a/mupt/geometry/shapes/cylinder.py
+++ b/mupt/geometry/shapes/cylinder.py
@@ -216,7 +216,7 @@ class Cylinder(BoundedTransformableShape):
 
     @property
     def L(self) -> float:
-        '''Alias for self.radius'''
+        '''Alias for self.length'''
         return self.length
 
     @property

--- a/mupt/geometry/shapes/visualize.py
+++ b/mupt/geometry/shapes/visualize.py
@@ -15,8 +15,49 @@ def visualize_shape(
     grid : bool=True, 
     **kwargs,
 ) -> 'Axes3D':
-    '''Convenience interface for plotting a surface mesh for a class implementing the BoundedShape Protocol'''
-    # DEV TODO: eventually, have a more standardized way to deal with these kinds of dependencies on import (a la @requires(...))
+    '''
+    Convenience function for plotting a surface mesh
+    for a class implementing the BoundedShape Protocol
+
+    Parameters
+    ----------
+    shape : BoundedShape
+        Any object whose type implements the BoundedShape
+        Protocol, namely BoundedShape.surface_mesh()
+    ax : Optional[mpl.Axes3D], default None
+        The 3-dimensional matplotlib Axes to plot the mesh onto
+        If NoneType is provided, will generate a new Axes3D and return it
+
+        Provided to support chained plotting workflows (i.e. plot shape onto axes with other meshes)
+    grid : bool, default True
+        Whether or not to show the coordinate axis gridlines when plotting
+    **kwargs 
+        Contains keyword arguments which are passed on to:
+        * The particular implementation of BoundedShape.surface_mesh() for the subtype
+          of shape being plotted (e.g. Sphere and Ellipsoid accept "n_theta" and "n_phi" mesh parameters)
+          
+          For example:
+          >> from mupt.geometry.shapes.ellipsoid import Sphere
+          >> shape = Sphere(1)
+          >> visualize_shape(shape, n_theta=50)
+
+        * Axes3D.plot_trisurf() (https://matplotlib.org/stable/api/_as_gen/mpl_toolkits.mplot3d.axes3d.Axes3D.plot_trisurf.html)
+          
+          Acceptable values are anything arguments which can be passed into a
+          matplotlib.collections.Collection, namely attributes assignable by Collection.set() 
+          (https://matplotlib.org/stable/api/collections_api.html#matplotlib.collections.Collection.set)
+
+          "color", "alpha", and "grid" are commonly-used args, viz.:
+          >> visualize_shape(shape, color='b', alpha=0.5)
+
+    Returns
+    -------
+    axes : mpl.Axes3D
+        The 3D axes the BoundedShape has been drawn on
+        Enables chaining plotting operations
+    '''
+    # DEV TODO: eventually, have a more standardized way to deal with 
+    # these kinds of dependencies on import (a la @requires(...))
     try:
         from matplotlib.axes import Axes
         from mpl_toolkits.mplot3d import Axes3D

--- a/mupt/geometry/transforms/rigid/__init__.py
+++ b/mupt/geometry/transforms/rigid/__init__.py
@@ -12,30 +12,28 @@ from .rotations import rotator, rodrigues, alignment_rotation
 from .alignment import rigid_vector_coalignment
 
 
-def random_rigid_transformation(
-    centered : bool=False,
-    translation_bound : float=1.0,
-) -> RigidTransform:
+def random_rigid_transformation(translation_bound : float=0.0) -> RigidTransform:
     """
     Generate a random rigid transformation, with both translation and rotation components by default
 
     Parameters
     ----------
-    centered : bool, default False
-        Whether the transformation should contain a translational component
-    translation_bound : float, default 1.0
+    translation_bound : float, default 0.0
         Uniform bound along all Cartesian axes for translation component
-        E.g. translation_bound=5.0 will pick a random translation vector from the set [-5, 5]**3
+        E.g. translation_bound=5.0 will pick a random translation vector from the set [-5.0, 5.0]**3
+
+        If 0.0 bound is provided (default), resulting transformation will have NO translational component
 
     Returns
     -------
     rand_transform : RigidTransform
         The resulting randomized rigid transformation
     """
-    if centered:
-        translation_bound = 0.0
-    
     return RigidTransform.from_components(
-        translation=np.random.uniform(-translation_bound, translation_bound, size=3),
+        translation=np.random.uniform(
+            -translation_bound,
+            translation_bound,
+            size=3,
+        ),
         rotation=Rotation.random(),
     )

--- a/mupt/mupr/connection.py
+++ b/mupt/mupr/connection.py
@@ -30,8 +30,8 @@ import numpy as np
 from scipy.spatial.transform import Rotation, RigidTransform
 
 from ..chemistry.core import BondType
-from ..geometry.arraytypes import Shape, Vector3, as_n_vector, compare_optional_positions
-from ..geometry.measure import within_ball
+from ..geometry.arraytypes import Shape, Vector3, as_n_vector
+from ..geometry.measure import compare_optional_positions
 from ..geometry.coordinates.basis import is_orthonormal
 from ..geometry.transforms.linear import rejector
 from ..geometry.transforms.rigid.rotations import alignment_rotation
@@ -109,7 +109,7 @@ class AttachmentPoint(RigidlyTransformable):
             if (value is not None) and (value not in self.attachables):
                 raise ValueError(f'Attachment "{value!s}" not designated as one of attachable labels {self.attachables}')
         if key == 'position':
-            value = as_n_vector(value, 3)
+            value = as_n_vector(value, dimension=3)
         return super().__setattr__(key, value)
         
     # Implementing RigidTransformable contracts
@@ -182,7 +182,7 @@ class Connector(RigidlyTransformable):
     @bond_vector.setter
     def bond_vector(self, new_bond_vector : Vector3) -> None:
         # TODO: cast this as a rigid transformation of linker to track cumulative transform? (would enable reset of bond length history)
-        self.linker.position = as_n_vector(new_bond_vector, 3) + self.anchor.position
+        self.linker.position = as_n_vector(new_bond_vector, dimension=3) + self.anchor.position
         
     @property
     def bond_length(self) -> float:
@@ -219,7 +219,7 @@ class Connector(RigidlyTransformable):
     @tangent_vector.setter
     def tangent_vector(self, new_tangent_vector : Vector3) -> None:
         '''Update tangent positions given a new tangent vector'''
-        new_tangent_vector = as_n_vector(new_tangent_vector, 3)
+        new_tangent_vector = as_n_vector(new_tangent_vector, dimension=3)
         if not np.isclose(
             np.dot( # DEV: opting not to normalize here in case either vector has small magnitude - revisit if that becomes an issue
                 self.bond_vector,
@@ -289,7 +289,7 @@ class Connector(RigidlyTransformable):
             metadata=deepcopy(self.metadata),
         )
         if self.has_tangent_position:
-            new_connector.tangent_vector = as_n_vector(self.tangent_vector, 3)
+            new_connector.tangent_vector = as_n_vector(self.tangent_vector, dimension=3)
 
         return new_connector
 
@@ -310,12 +310,12 @@ class Connector(RigidlyTransformable):
         of the other Connector, and vice-versa (with the same tolerance for both)
         '''
         return (
-            within_ball(
+            compare_optional_positions(
                 self.anchor.position,
                 other.linker.position,
                 radius=within,
             )
-            and within_ball(
+            and compare_optional_positions(
                 self.linker.position,
                 other.anchor.position,
                 radius=within,

--- a/mupt/mupr/connection/__init__.py
+++ b/mupt/mupr/connection/__init__.py
@@ -7,6 +7,7 @@ from .types import (
     AttachmentLabel,
     ConnectorLabel,
     ConnectorHandle,
+    ConnectorAddress,
     ManagesConnectors,
 )
 from .exceptions import (
@@ -18,4 +19,5 @@ from .exceptions import (
 from .connectors import (
     AttachmentPoint,
     Connector,
+    canonical_form_connectors,
 )

--- a/mupt/mupr/connection/__init__.py
+++ b/mupt/mupr/connection/__init__.py
@@ -1,0 +1,21 @@
+'''Abstractions of connections between structural units'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+from .types import (
+    AttachmentLabel,
+    ConnectorLabel,
+    ConnectorHandle,
+    ManagesConnectors,
+)
+from .exceptions import (
+    ConnectionError,
+    IncompatibleConnectorError,
+    MissingConnectorError,
+    UnboundConnectorError,
+)
+from .connectors import (
+    AttachmentPoint,
+    Connector,
+)

--- a/mupt/mupr/connection/alignment.py
+++ b/mupt/mupr/connection/alignment.py
@@ -1,7 +1,267 @@
-'''Strategies for ensuring spatial alignment of pairs on Connectors forming a connection'''
+'''
+Strategies for checking and enacting spatial anti-alignment of pairs of
+Connectors which comprise a connection. Models bonding in 3D space
+'''
 
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
 
-# TODO: separate impls from Connector methods (currently rigid and ballistic) and move here as strategies
-...
+from typing import Optional, TYPE_CHECKING
+from abc import ABC, abstractmethod
+
+from scipy.spatial.transform import Rotation, RigidTransform
+
+from ...geometry.measure import within_ball
+from ...geometry.transforms.rigid.rotations import alignment_rotation
+if TYPE_CHECKING:
+    from .connectors import Connector
+
+
+def are_antialigned(
+    align_connector : 'Connector',
+    to_connector : 'Connector',
+    within : float=1E-6,
+) -> bool:
+    '''
+    Whether `align_connector` is anti-aligned with `to_connector`, i.e. whether 
+    the anchor of `align_connector` is within some cutoff distance of the linker
+    of the `to_connector`, and vice-versa (with the same tolerance for both)
+
+    N.B.: this operation is commutative, i.e. are_antialigned(Ca, Cb) = are_antialigned(Cb, Ca)
+    '''
+    return (
+        within_ball(
+            align_connector.anchor.position,
+            to_connector.linker.position,
+            radius=within,
+        )
+        and within_ball(
+            align_connector.linker.position,
+            to_connector.anchor.position,
+            radius=within,
+        )
+    )
+    
+class ConnectorAntialignmentStrategy(ABC):
+    '''
+    Defines interface for antialigning one Connector with another
+    I.e. Transforming one connector so that its linker is coincident to 
+    the other's anchor and vice versa WITHOUT modifying the `to_connector` 
+    '''
+    @abstractmethod
+    def antialignment_transformation(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+    ) -> RigidTransform:
+        '''
+        A rigid transformation applied to `align_connector` to line it up 
+        with `to_connector` for the antialignment procedure implemented here
+        '''
+        ...
+
+    @abstractmethod
+    def _antialign(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+    ) -> None:
+        '''
+        Implementation of how Connector `align_connector` should be
+        acted on to antialign it to Connector `to_connector`
+        
+        Note: do NOT include changes to bond length here;
+        those are bundled automatically with `antialign()`
+        '''
+        # DEV: made this a separate method (rather than always 
+        # just applying `self.antialignment_transformation()`)
+        # to allow alignment techniques potentially not based 
+        # on rigid transformations to fit within this framework
+        ...
+
+    def antialign(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+        match_bond_length : bool=False,
+        dihedral_angle_rad : Optional[float]=None,
+    ) -> None:
+        '''
+        Apply the requisite antialignment transformation and other modifications to `align_connector`
+        so that it is antialigned with `to_connector` in-place WITHOUT modifying `to_connector` itself
+
+        If match_bond_length = True, will also stretch/compress bond 
+        length on `align_connector` to match length of `to_connector`
+        '''
+        self._antialign(
+            align_connector=align_connector,
+            to_connector=to_connector,
+        )
+        if match_bond_length: 
+            align_connector.set_bond_length(to_connector.bond_length)
+
+        if (dihedral_angle_rad is not None): # NOTE: sentinel (rather than default 0.0) weakens preconditions on tangents when no dihedral is specified
+            align_connector.assign_dihedral(
+                to_connector,
+                dihedral_angle_rad=dihedral_angle_rad,
+            )
+
+    def antialigned(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+        match_bond_length : bool=False,
+        dihedral_angle_rad : Optional[float]=None,
+    ) -> 'Connector':
+        '''
+        Return a copy of `align_connector` which is antialigned with `to_connector`
+        WITHOUT modifying either `align_connector` or `to_connector`
+
+        Non-in-place version of `self.antialign()`
+        '''
+        align_connector_new = align_connector.copy()
+        self.antialign(
+            align_connector,
+            to_connector=to_connector,
+            match_bond_length=match_bond_length,
+            dihedral_angle_rad=dihedral_angle_rad,
+        )
+        return align_connector_new
+    
+    def mutually_antialign(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+        dihedral_angle_rad : Optional[float]=None,
+    ) -> None:
+        '''
+        Apply anti-alignment implemented here first to
+        Designed to accomodate assymetric alignment schemes
+
+        If a dihedral angle is provided, will also rotate
+        `align_connector` along the mutual bond axis to that angle
+        '''
+        self.antialign(
+            align_connector,
+            to_connector=to_connector,
+            match_bond_length=True,
+            dihedral_angle_rad=None, # dihedrals done at end
+        )
+        self.antialign(
+            to_connector,
+            to_connector=align_connector,
+            match_bond_length=True,
+            dihedral_angle_rad=None, # dihedrals done at end
+        )
+        ### DEV: asymmetry relative to rigid alignment viz dihedral angles is no accident;
+        ### Rigid alignment results in antialignment after one application with bond length matching,
+        ### whereas ballistic alignment in general requires both Connectors to be mutually transformed to guarantee antialignment
+        if (dihedral_angle_rad is not None): # NOTE: sentinel (rather than default 0.0) weakens preconditions on tangents when no dihedral is specified
+            align_connector.assign_dihedral(
+                to_connector,
+                dihedral_angle_rad=dihedral_angle_rad,
+            )
+
+
+class ConnectorAntialignmentRigid(ConnectorAntialignmentStrategy):
+    '''
+    Antialignment strategy which works purely through rigid motions
+    I.e. only translates and rotates `align_connector` without distorting or modifying it
+    '''
+    def __init__(self, tare_dihedrals : bool=False) -> None:
+        self.tare_dihedrals = tare_dihedrals
+
+    def antialignment_transformation(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+    ) -> RigidTransform:
+        '''
+        Compute a rigid transformation which antialigns a pair of Connectors by making
+        the linker point of `align_connector` coincident with the anchor of the `to_connector`
+        
+        If the two Connectors have the same bond length, the anchor of `align_connector` will be coincident with the linker
+        of the other; otherwise, the anchor will merely lay on the span of the `to_connector`s bond vector
+        
+        If tare_dihedrals is True (default False), will also ensure that the dihedral planes of the two Connectors are coplanar
+        this may be desirable in many cases, but comes with stricter preconditions, namely both connectors having tangents define
+        '''
+        bond_antialignment : Rotation = alignment_rotation(
+            align_connector.unit_bond_vector,
+            -to_connector.unit_bond_vector
+        )
+        
+        if self.tare_dihedrals:
+            tangent_alignment = alignment_rotation(
+                bond_antialignment.apply(align_connector.tangent_vector),
+                to_connector.tangent_vector,
+            )
+        else:
+            tangent_alignment = Rotation.identity()
+        
+        return ( # order of application of operations reads bottom-to-top (rightmost operator acts first)
+            RigidTransform.from_translation(to_connector.linker.position)
+            * RigidTransform.from_rotation(tangent_alignment)
+            * RigidTransform.from_rotation(bond_antialignment)
+            * RigidTransform.from_translation(-align_connector.anchor.position)
+        )
+
+    def _antialign(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+    ) -> None:
+        '''
+        Align `align_connector` rigidly to `to_connector`, 
+        based on the calculated rigid alignment transform
+        '''
+        align_connector.rigidly_transform(
+            transformation=self.antialignment_transformation(
+                align_connector,
+                to_connector=to_connector,
+            )
+        )
+
+class ConnectorAntialignmentBallistic(ConnectorAntialignmentStrategy):
+    '''
+    Antialignment strategy which points-and-aims at `to-connector`
+    without requiring any rigid motion of adjoining bodies
+
+    Called "ballistic" because the action (especially when matching bond length)
+    resembles `align_connector` aiming and then "shooting" its linker at `to_connector`
+    '''
+
+    def antialignment_transformation(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+    ) -> RigidTransform:
+        '''
+        Compute a rigid transformation which aligns a pair of Connectors by turning
+        the bond vector of `align_connector`` to face the linker point of `to_connector`
+        The anchor positions of either Connector will be unaffected
+        '''
+        return (
+            RigidTransform.from_translation(align_connector.anchor.position)
+            * RigidTransform.from_rotation(alignment_rotation(
+                align_connector.bond_vector,
+                to_connector.anchor.position - align_connector.anchor.position),
+            )
+            * RigidTransform.from_translation(-align_connector.anchor.position)
+        )
+    
+    def _antialign(
+        self,
+        align_connector : 'Connector',
+        to_connector : 'Connector',
+    ) -> None:
+        '''
+        Align `align_connector` with `to_connector` by rotating the bond vector of
+        `align_connector` bond vector to aim at `the anchor point of `to_connector`
+        '''
+        align_connector.rigidly_transform(
+            transformation=self.antialignment_transformation(
+                align_connector,
+                to_connector=to_connector,
+            )
+        )

--- a/mupt/mupr/connection/alignment.py
+++ b/mupt/mupr/connection/alignment.py
@@ -1,0 +1,7 @@
+'''Strategies for ensuring spatial alignment of pairs on Connectors forming a connection'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+# TODO: separate impls from Connector methods (currently rigid and ballistic) and move here as strategies
+...

--- a/mupt/mupr/connection/alignment.py
+++ b/mupt/mupr/connection/alignment.py
@@ -11,7 +11,7 @@ from abc import ABC, abstractmethod
 
 from scipy.spatial.transform import Rotation, RigidTransform
 
-from ...geometry.measure import within_ball
+from ...geometry.measure import compare_optional_positions
 from ...geometry.transforms.rigid.rotations import alignment_rotation
 if TYPE_CHECKING:
     from .connectors import Connector
@@ -30,12 +30,12 @@ def are_antialigned(
     N.B.: this operation is commutative, i.e. are_antialigned(Ca, Cb) = are_antialigned(Cb, Ca)
     '''
     return (
-        within_ball(
+        compare_optional_positions(
             align_connector.anchor.position,
             to_connector.linker.position,
             radius=within,
         )
-        and within_ball(
+        and compare_optional_positions(
             align_connector.linker.position,
             to_connector.anchor.position,
             radius=within,

--- a/mupt/mupr/connection/alignment.py
+++ b/mupt/mupr/connection/alignment.py
@@ -121,7 +121,7 @@ class ConnectorAntialignmentStrategy(ABC):
         '''
         align_connector_new = align_connector.copy()
         self.antialign(
-            align_connector,
+            align_connector_new,
             to_connector=to_connector,
             match_bond_length=match_bond_length,
             dihedral_angle_rad=dihedral_angle_rad,

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -32,8 +32,8 @@ from .types import AttachmentLabel, ConnectorLabel, ConnectorHandle
 from .alignment import are_antialigned
 from ..canonicalize import lex_order_multiset_str
 from ...chemistry.core import BondType, BOND_ORDER
-from ...geometry.arraytypes import Vector3, Array3x3, as_n_vector, compare_optional_positions
-from ...geometry.measure import within_ball
+from ...geometry.arraytypes import Vector3, Array3x3, as_n_vector
+from ...geometry.measure import compare_optional_positions
 from ...geometry.coordinates.basis import is_orthonormal
 from ...geometry.transforms.linear import rejector
 from ...geometry.transforms.rigid.rotations import alignment_rotation
@@ -312,7 +312,7 @@ class Connector(RigidlyTransformable):
         the anchor of this Connector is within some cutoff distance of the linker
         of the other Connector, and vice-versa (with the same tolerance for both)
         '''
-        return are_antialigned(self, other)
+        return are_antialigned(self, other, within=within)
       
     ## Comparison methods
     def bondable_with(self, other : 'Connector') -> bool:

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -453,12 +453,27 @@ class Connector(RigidlyTransformable):
             raise TypeError(f'Connector label must be a Hashable type, not {type(new_label)}')
         self._label = new_label
         
+    # def __hash__(self) -> int:
+    #     return hash((
+    #         self.address
+    #         self.anchor,
+    #         # self.linker,
+    #         frozenset(self.linkables), # TODO: make linkables frozen at __init__ level to avoid post-init mutation?
+    #         *self.is_position_assigned.keys(),
+    #     ))
+    #     # raise NotImplementedError # DEVNOTE: need to decide what info should (and shouldn't) go into the making of this sausage
+    
+    # def __eq__(self, other : 'Connector') -> bool:
+    #     # return hash(self) == hash(other)
+    #     return self.fungible_with(other)
+    
+    @property
     def address(self) -> int:
         '''
         Unique identifier used to identify this Connector instances,
         irrespective of similarity to other Connectors
         '''
-        return id(self)
+        raise NotImplementedError # TODO: find hasing strategy that is more robust than id(...) (volatile, and w/o many desired properties)
     
     def canonical_form(self) -> BondType:
         '''Return a canonical form used to distinguish equivalent Connectors'''
@@ -480,20 +495,6 @@ class Connector(RigidlyTransformable):
         )
         
         return f'{self.__class__.__name__}({attr_str})'
-
-    # def __hash__(self) -> int:
-    #     return hash((
-    #         # id(self),
-    #         self.anchor,
-    #         # self.linker,
-    #         frozenset(self.linkables), # TODO: make linkables frozen at __init__ level to avoid post-init mutation?
-    #         *self.is_position_assigned.keys(),
-    #     ))
-    #     # raise NotImplementedError # DEVNOTE: need to decide what info should (and shouldn't) go into the making of this sausage
-    
-    # def __eq__(self, other : 'Connector') -> bool:
-    #     # return hash(self) == hash(other)
-    #     return self.fungible_with(other)
     
 
 # Canonicalization

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -329,21 +329,6 @@ class Connector(RigidlyTransformable):
             and (self.bondtype == other.bondtype)
         )
         
-    def bondable_with_iter(
-        self,
-        *others : Iterable[Union['Connector', Iterable['Connector']]],
-    ) -> Generator[Union[bool, Iterable[bool]], None, None]:
-        '''Whether this Connector can be connected to each of a sequence of other Connectors, in the order passed'''
-        for other in others:
-            if isinstance(other, Connector):
-                yield self.bondable_with(other)
-            elif isinstance(other, Iterable):
-                # DEVNOTE: deliberately NOT using "yield from" to preserve parity with input
-                # (output element corresponding to iterable is now just a Generator instance, rather than a bool)
-                yield self.bondable_with_iter(*other)
-            else:
-                raise TypeError(f'Connector can only be bonded to other Connectors or collection of Connectors, not with object of type {type(other)}')
-
     def coincides_with(self, other : 'Connector') -> bool:
         '''Whether this Connector overlaps spatially with another Connector'''
         return ( # TODO: set atol/rtol for float vector comparison

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -12,14 +12,12 @@ LOGGER = logging.getLogger(__name__)
 
 from typing import (
     Any,
+    Callable,
     ClassVar,
-    Generator,
     Hashable,
     Iterable,
     Optional,
-    Union,
 )
-from warnings import warn
 
 from dataclasses import dataclass, field
 from copy import deepcopy
@@ -91,17 +89,17 @@ class Connector(RigidlyTransformable):
         label : Optional[ConnectorLabel]=None,
         metadata : Optional[dict[Hashable, Any]]=None,
     ):
-        self.anchor = anchor if (anchor is not None) else AttachmentPoint()
-        self.linker = linker if (linker is not None) else AttachmentPoint()
+        self.anchor : AttachmentPoint = anchor if (anchor is not None) else AttachmentPoint()
+        self.linker : AttachmentPoint = linker if (linker is not None) else AttachmentPoint()
         
-        self.bondtype = bondtype
-        self.query_smarts = query_smarts
-        self.label = self.__class__.DEFAULT_LABEL if (label is None) else label
-        self.metadata = metadata or dict()
+        self.bondtype : BondType = bondtype
+        self.query_smarts : str = query_smarts
+        self.label : Hashable = self.__class__.DEFAULT_LABEL if (label is None) else label
+        self.metadata : dict[Hashable, Any] = metadata or dict()
 
         ## Protected attributes
         self._neighbor : Optional[Connector] = None
-        self._parents : list[ManagesConnectors] = list()
+        self._managers : list[ManagesConnectors] = list()
         self._tangent_position = None # DEV: no call to setter; must be assigned via protected tangent_vector property
 
     @property
@@ -314,6 +312,31 @@ class Connector(RigidlyTransformable):
         if self.has_tangent_position:
             self._tangent_position = transformation.apply(self._tangent_position)
 
+    # Parents
+    @property
+    def managers(self) -> list[ManagesConnectors]:
+        return self._managers
+    # N.B.: deliberately excluded managers.setter; moderated thru add_manager and remove_manager methods instead
+
+    def add_manager(
+        self,
+        manager : ManagesConnectors,
+        ranking : Optional[Callable[[ManagesConnectors], int]]=None,
+    ) -> None:
+        '''
+        Insert new manager into registry of manager connector managers
+        If ranking Callable is given, will apply to sort managers in-place post-insertion
+        '''
+        if manager in self._managers:
+            raise IndexError(f'The Connector manager {manager!r} is already present in the registry of Connector {self!r}')
+        self._managers.append(manager)
+
+        if ranking:
+            self._managers.sort(key=ranking, reverse=False)
+
+    def remove_manager(self, manager : ManagesConnectors) -> None:
+        self._managers.remove(manager) # no need to check membership - already raises ValueError if not present
+
     # Interactions with neighboring Connectors
     ## Comparison methods
     def bondable_with(self, other : 'Connector') -> bool:
@@ -322,7 +345,7 @@ class Connector(RigidlyTransformable):
             return False # DEVNOTE: raise TypeError instead (or at least log a warning)?
         # DEV: opting for loosest possible comparison where at least on of the attachable elements overlaps between opposing pairs of attachment points
         # opted not to check the (perhaps more obvious) "self.anchor.attachment in other.linker.attachables", etc., 
-        # because the attachment labels may be unassigned between resolution shift operations in the representation hierarchy
+        # because the attachment labels may differ between resolution shift operations in the representation hierarchy
         return ( 
             (not set.isdisjoint(self.anchor.attachables, other.linker.attachables))
             and (not set.isdisjoint(self.linker.attachables, other.anchor.attachables))

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -498,7 +498,11 @@ class Connector(RigidlyTransformable):
     
 
 # Canonicalization
-def canonical_form_connectors(connectors: Iterable[Connector], separator : str=':', joiner : str='-') -> str:
+def canonical_form_connectors(
+    connectors: Iterable[Connector],
+    separator : str=':',
+    joiner : str='-',
+) -> str:
     '''A hashable string representing a collection of Connectors in canonical form'''
     return lex_order_multiset_str(
         map(Connector.canonical_form, connectors), # TODO: sort by some metric?

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -29,6 +29,7 @@ import numpy as np
 from scipy.spatial.transform import Rotation, RigidTransform
 
 from .types import AttachmentLabel, ConnectorLabel, ConnectorHandle
+from .alignment import are_antialigned
 from ..canonicalize import lex_order_multiset_str
 from ...chemistry.core import BondType, BOND_ORDER
 from ...geometry.arraytypes import Vector3, Array3x3, as_n_vector, compare_optional_positions
@@ -220,50 +221,6 @@ class Connector(RigidlyTransformable):
         
         return local_orthonormal_basis
     
-    # Applying rigid transformations (fulfilling RigidlyTransformable contracts)
-    def _copy_untransformed(self) -> 'Connector':
-        new_connector = self.__class__(
-            anchor=self.anchor.copy(),
-            linker=self.linker.copy(),
-            bondtype=self.bondtype,
-            query_smarts=str(self.query_smarts),
-            label=self._label,
-            metadata=deepcopy(self.metadata),
-        )
-        if self.has_tangent_position:
-            new_connector.tangent_vector = as_n_vector(self.tangent_vector, 3)
-
-        return new_connector
-
-    def _rigidly_transform(self, transformation : RigidTransform) -> None:
-        self.anchor.rigidly_transform(transformation)
-        self.linker.rigidly_transform(transformation)
-        if self.has_tangent_position:
-            self._tangent_position = transformation.apply(self._tangent_position)
-
-    # Anti-aligning Connectors to one another (simulates bonding in 3D space)
-    ## DEV: eventually try to move as much of the implementation of these transforms to geometry.transforms.rigid as possible
-    def are_antialigned(self, other : 'Connector', within : float=1E-6) -> bool:
-        ## DEV: was unsure of whether or not to make this a classmethod; opted for instance method instead, with the understanding
-        ## that you can still call it like a classmethod (i.e. conn1.align(conn2) <-> Connector.align(conn1, conn2))
-        '''
-        Whether this Connector is anti-aligned with another Connector, i.e. whether 
-        the anchor of this Connector is within some cutoff distance of the linker
-        of the other Connector, and vice-versa (with the same tolerance for both)
-        '''
-        return (
-            within_ball(
-                self.anchor.position,
-                other.linker.position,
-                radius=within,
-            )
-            and within_ball(
-                self.linker.position,
-                other.anchor.position,
-                radius=within,
-            )
-        )
-        
     ## Dihedral angle
     def dihedral_assignment_transform(
         self,
@@ -326,137 +283,42 @@ class Connector(RigidlyTransformable):
         )
         
         return new_connector
-
-    ## Rigid alignment
-    def rigid_antialignment_to(
-        self, 
-        other : 'Connector',
-        tare_dihedrals : bool=False,
-    ) -> RigidTransform:
-        '''
-        Compute a rigid transformation which antialigns a pair of Connectors by making
-        the linker point of this Connector coincident with the anchor of the other Connector
-        
-        If the two Connectors have the same bond length, the anchor of this Connector will be coincident with the linker
-        of the other; otherwise, the anchor will merely lay on the span of the other Connectors bond vector
-        
-        If tare_dihedrals is True (default False), will also ensure that the dihedral planes of the two Connectors are coplanar
-        this may be desirable in many cases, but comes with stricter preconditions, namely both connectors having tangents define
-        '''
-        bond_antialignment : Rotation = alignment_rotation(self.unit_bond_vector, -other.unit_bond_vector)
-        if tare_dihedrals:
-            tangent_alignment = alignment_rotation(bond_antialignment.apply(self.tangent_vector), other.tangent_vector)
-        else:
-            tangent_alignment = Rotation.identity()
-        
-        return ( # order of application of operations reads bottom-to-top (rightmost operator acts first)
-            RigidTransform.from_translation(other.linker.position)
-            * RigidTransform.from_rotation(tangent_alignment)
-            * RigidTransform.from_rotation(bond_antialignment)
-            * RigidTransform.from_translation(-self.anchor.position)
+    
+    # Applying rigid transformations (fulfilling RigidlyTransformable contracts)
+    def _copy_untransformed(self) -> 'Connector':
+        new_connector = self.__class__(
+            anchor=self.anchor.copy(),
+            linker=self.linker.copy(),
+            bondtype=self.bondtype,
+            query_smarts=str(self.query_smarts),
+            label=self._label,
+            metadata=deepcopy(self.metadata),
         )
-
-    def antialign_rigidly_to(
-        self,
-        other : 'Connector',
-        tare_dihedrals : bool=False,
-        dihedral_angle_rad : Optional[float]=None,
-        match_bond_length : bool=False,
-    ) -> None:
-        '''Align this Connector rigidly to another Connector, based on the calculated rigid alignment transform'''
-        self.rigidly_transform(transformation=self.rigid_antialignment_to(other, tare_dihedrals=tare_dihedrals))
-        if match_bond_length: 
-            self.set_bond_length(other.bond_length) # ensure bond length matches the other Connector
-            if (dihedral_angle_rad is not None): # NOTE: sentinel (rather than default 0.0) weakens preconditions on tangents when no dihedral is specified
-                self.assign_dihedral(other, dihedral_angle_rad=dihedral_angle_rad)
-
-    def antialigned_rigidly_to(
-        self,
-        other : 'Connector',
-        tare_dihedrals : bool=False,
-        dihedral_angle_rad : Optional[float]=None,
-        match_bond_length : bool=False,
-    ) -> 'Connector':
-        '''Return a copy of this Connector rigidly aligned to another Connector'''
-        new_connector = self.copy()
-        new_connector.antialign_rigidly_to(
-            other,
-            tare_dihedrals=tare_dihedrals,
-            dihedral_angle_rad=dihedral_angle_rad,
-            match_bond_length=match_bond_length,
-        )
+        if self.has_tangent_position:
+            new_connector.tangent_vector = as_n_vector(self.tangent_vector, 3)
 
         return new_connector
-    
-    ## Ballistic alignment
-    def ballistic_antialignment_to(self, other : 'Connector') -> RigidTransform:
-        '''
-        Compute a rigid transformation which aligns a pair of Connectors by turning
-        the bond vector of this Connector to face the linker point of other Connector
-        The anchor positions of either Connector will be unaffected
-        
-        Called "ballistic" because the action (especially when matching bond length)
-        resembles this Connector aiming and then "shooting" its linker at the other Connector
-        '''
-        return (
-            RigidTransform.from_translation(self.anchor.position)
-            * RigidTransform.from_rotation(alignment_rotation(self.bond_vector, other.anchor.position - self.anchor.position))
-            * RigidTransform.from_translation(-self.anchor.position)
-        )
-    
-    def antialign_ballistically_to(
-        self,
-        other : 'Connector',
-        match_bond_length : bool=False,
-    ) -> None:
-        '''
-        Match linker position of this Connector to the anchor position of the other Connector (if assigned)
-        NOTE: does NOT modify the other Connector, only acts on the first Connector of the provided pair
-        '''
-        self.rigidly_transform(transformation=self.ballistic_antialignment_to(other))
-        if match_bond_length:
-            self.set_bond_length(np.linalg.norm(other.anchor.position - self.anchor.position))
 
-    def antialigned_ballistically_to(
-        self,
-        other : 'Connector',
-        match_bond_length : bool=False,
-    ) -> 'Connector':
-        '''
-        Return copy of this Connector whose linker positions is aligned to the anchor position of the other Connector (if assigned)
-        NOTE: does NOT modify either Connector of the passed pair; returns a modified copy of the first Connector
-        '''
-        new_connector = self.copy() # DEV: opted not to go for self.rigidly_transformed(self.alignment_transform(...)) to avoid duplicating logic
-        new_connector.antialign_ballistically_to(other, match_bond_length=match_bond_length)
-        
-        return new_connector
-    
-    ### DEV: asymmetry relative to rigid alignment viz dihedral angles is no accident;
-    ### Rigid alignment results in antialignment after one application with bond length matching,
-    ### whereas ballistic alignment in general requires both Connecters to be mutually transformed to guarantee antialignment
-    def mutually_antialign_ballistically(
-        self,
-        other : 'Connector',
-        dihedral_angle_rad : Optional[float]=None,
-    ) -> None:
-        '''
-        Ballistically align this Connector to the other, and vice-versa
-        In the end, the linker of either Connector with be coincident with the
-        anchor of the other, and the anchors sites will not have been moved
+    def _rigidly_transform(self, transformation : RigidTransform) -> None:
+        self.anchor.rigidly_transform(transformation)
+        self.linker.rigidly_transform(transformation)
+        if self.has_tangent_position:
+            self._tangent_position = transformation.apply(self._tangent_position)
 
-        If a dihedral angle is provided, will also rotate this Connector along the mutual bond axis to that angle
+    # Interactions with neighboring Connectors
+    def are_antialigned(self, other : 'Connector', within : float=1E-6) -> bool:
         '''
-        self.antialign_ballistically_to(other, match_bond_length=True)
-        other.antialign_ballistically_to(self, match_bond_length=True)
-        if (dihedral_angle_rad is not None): # NOTE: sentinel (rather than default 0.0) weakens preconditions on tangents when no dihedral is specified
-            self.assign_dihedral(other, dihedral_angle_rad=dihedral_angle_rad)
-
-    # Comparison methods
+        Whether this Connector is anti-aligned with another Connector, i.e. whether 
+        the anchor of this Connector is within some cutoff distance of the linker
+        of the other Connector, and vice-versa (with the same tolerance for both)
+        '''
+        return are_antialigned(self, other)
+      
+    ## Comparison methods
     def bondable_with(self, other : 'Connector') -> bool:
         '''Whether this Connector is bondable with another Connector instance'''
         if not isinstance(other, Connector):
             return False # DEVNOTE: raise TypeError instead (or at least log a warning)?
-        
         # DEV: opting for loosest possible comparison where at least on of the attachable elements overlaps between opposing pairs of attachment points
         # opted not to check the (perhaps more obvious) "self.anchor.attachment in other.linker.attachables", etc., 
         # because the attachment labels may be unassigned between resolution shift operations in the representation hierarchy
@@ -504,7 +366,7 @@ class Connector(RigidlyTransformable):
         '''Whether this connector can replace other without any change to programs which involve it'''
         return self.coincides_with(other) and self.resembles(other)
 
-    ## Labelling and representation methods
+    # Labelling and representation methods
     @property
     def label(self) -> ConnectorLabel:
         '''Identifying label for this Connector'''

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -107,19 +107,6 @@ class Connector(RigidlyTransformable):
     ## preserving relative orientations for local orthogonal basis under general rigid transformations; key observation is that 
     ## a DIFFERENCE between positions is invariant under shifts of the origin, i.e. if v = (a - b), Tv = T(a - b) = T(a) - T(b), 
     
-    ## Attachment site position wrappers - DEV: necessary for backward compatibility with attr reference, though could be deprecated eventually
-    @property
-    def anchor_position(self) -> Vector3:
-        '''The central position that this Connector is anchored to'''
-        warn('Connector.anchor_position is slated for deprecation; use Connector.anchor.position instead', category=DeprecationWarning)
-        return self.anchor.position
-        
-    @property
-    def linker_position(self) -> Vector3:
-        '''The position of the off-body linker point'''
-        warn('Connector.linker_position is slated for deprecatation; use Connector.linker.position instead', category=DeprecationWarning)
-        return self.linker.position
-
     ## Bond vector
     @property
     def has_bond_vector(self) -> bool:

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -61,7 +61,7 @@ class AttachmentPoint(RigidlyTransformable):
             if (value is not None) and (value not in self.attachables):
                 raise ValueError(f'Attachment "{value!s}" not designated as one of attachable labels {self.attachables}')
         if key == 'position':
-            value = as_n_vector(value, 3)
+            value = as_n_vector(value, dimension=3)
         return super().__setattr__(key, value)
         
     # Implementing RigidTransformable contracts
@@ -132,7 +132,7 @@ class Connector(RigidlyTransformable):
     @bond_vector.setter
     def bond_vector(self, new_bond_vector : Vector3) -> None:
         # TODO: cast this as a rigid transformation of linker to track cumulative transform? (would enable reset of bond length history)
-        self.linker.position = as_n_vector(new_bond_vector, 3) + self.anchor.position
+        self.linker.position = as_n_vector(new_bond_vector, dimension=3) + self.anchor.position
         
     @property
     def bond_length(self) -> np.floating:
@@ -169,7 +169,7 @@ class Connector(RigidlyTransformable):
     @tangent_vector.setter
     def tangent_vector(self, new_tangent_vector : Vector3) -> None:
         '''Update tangent positions given a new tangent vector'''
-        new_tangent_vector = as_n_vector(new_tangent_vector, 3)
+        new_tangent_vector = as_n_vector(new_tangent_vector, dimension=3)
         if not np.isclose(
             np.dot( # DEV: opting not to normalize here in case either vector has small magnitude - revisit if that becomes an issue
                 self.bond_vector,
@@ -302,7 +302,7 @@ class Connector(RigidlyTransformable):
             metadata=deepcopy(self.metadata),
         )
         if self.has_tangent_position:
-            new_connector.tangent_vector = as_n_vector(self.tangent_vector, 3)
+            new_connector.tangent_vector = as_n_vector(self.tangent_vector, dimension=3)
 
         return new_connector
 

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -28,8 +28,14 @@ from itertools import product as cartesian
 import numpy as np
 from scipy.spatial.transform import Rotation, RigidTransform
 
-from .types import AttachmentLabel, ConnectorLabel, ConnectorHandle
+from .types import (
+    AttachmentLabel,
+    ConnectorLabel,
+    ConnectorHandle,
+    ManagesConnectors,
+)
 from .alignment import are_antialigned
+from .exceptions import IncompatibleConnectorError
 from ..canonicalize import lex_order_multiset_str
 from ...chemistry.core import BondType, BOND_ORDER
 from ...geometry.arraytypes import Vector3, Array3x3, as_n_vector
@@ -92,7 +98,10 @@ class Connector(RigidlyTransformable):
         self.query_smarts = query_smarts
         self.label = self.__class__.DEFAULT_LABEL if (label is None) else label
         self.metadata = metadata or dict()
-    
+
+        ## Protected attributes
+        self._neighbor : Optional[Connector] = None
+        self._parents : list[ManagesConnectors] = list()
         self._tangent_position = None # DEV: no call to setter; must be assigned via protected tangent_vector property
 
     @property
@@ -306,14 +315,6 @@ class Connector(RigidlyTransformable):
             self._tangent_position = transformation.apply(self._tangent_position)
 
     # Interactions with neighboring Connectors
-    def are_antialigned(self, other : 'Connector', within : float=1E-6) -> bool:
-        '''
-        Whether this Connector is anti-aligned with another Connector, i.e. whether 
-        the anchor of this Connector is within some cutoff distance of the linker
-        of the other Connector, and vice-versa (with the same tolerance for both)
-        '''
-        return are_antialigned(self, other, within=within)
-      
     ## Comparison methods
     def bondable_with(self, other : 'Connector') -> bool:
         '''Whether this Connector is bondable with another Connector instance'''
@@ -326,7 +327,6 @@ class Connector(RigidlyTransformable):
             (not set.isdisjoint(self.anchor.attachables, other.linker.attachables))
             and (not set.isdisjoint(self.linker.attachables, other.anchor.attachables))
             and (self.bondtype == other.bondtype)
-            # TODO: also compare positions, if set?
         )
         
     def bondable_with_iter(
@@ -365,6 +365,72 @@ class Connector(RigidlyTransformable):
     def fungible_with(self, other : 'Connector') -> bool:
         '''Whether this connector can replace other without any change to programs which involve it'''
         return self.coincides_with(other) and self.resembles(other)
+
+    ## Neighbor configuration
+    def is_antialigned(self, other : 'Connector', within : float=1E-6) -> bool:
+        '''
+        Whether this Connector is anti-aligned with another Connector, i.e. whether 
+        the anchor of this Connector is within some cutoff distance of the linker
+        of the other Connector, and vice-versa (with the same tolerance for both)
+        '''
+        return are_antialigned(self, other, within=within)
+    
+    @property
+    def neighbor(self) -> Optional['Connector']:
+        '''
+        The Connector assigned to be this Connector's nieghbor, if assigned
+        If unassigned, returns None
+        '''
+        return self._neighbor
+
+    @neighbor.setter
+    def neighbor(self, other : 'Connector') -> None:
+        if not self.bondable_with(other):
+            raise IncompatibleConnectorError('Cannot make incompatible Connector neighbor')
+
+        # N.B.: if ALL positions are unset, will evaluate as antialigned
+        if not self.is_antialigned(other): 
+            raise IncompatibleConnectorError('Candidate for neighbor Connector is not anti-aligne within tolerance')
+        
+        self._neighbor = other
+
+    @neighbor.deleter
+    def neighbor(self) -> None:
+        self._neighbor = None
+
+    ## Copying and attr transfer methods
+    def individualize(self) -> dict[tuple[AttachmentLabel, AttachmentLabel], 'Connector']:
+        '''
+        Expand a Connector into a set of Connectors with identical properties but 
+        distinct, singletons linkables, one for each linkable in the original Connector
+        '''
+        indiv_conn_map = dict()
+        for anchor_label, linker_label in cartesian(self.anchor.attachables, self.linker.attachables):
+            conn_clone = self.copy()
+            conn_clone.anchor.attachment = anchor_label
+            conn_clone.anchor.attachables = {anchor_label}
+            
+            conn_clone.linker.attachment = linker_label
+            conn_clone.linker.attachables = {linker_label}
+
+            indiv_conn_map[(anchor_label, linker_label)] = conn_clone
+        return indiv_conn_map
+    
+    def counterpart(self) -> 'Connector':
+        '''
+        Create a counterpart Connector which is identical to this Connector but has its linker and anchor sites swapped
+        
+        By construction, the counterpart will always be bondable with this Connector (and vice versa),
+        assuming the attachables set of the anchor and linker point are both non-empty
+        '''
+        counterpart = self.copy()
+        counterpart.anchor, counterpart.linker = self.linker, self.anchor
+        if self.has_tangent_position:
+            # NOTE: since vector if defined by difference to tangent point, updated tangent 
+            # point can be set directly from this difference, since anchor is updated about
+            counterpart.tangent_vector = self.tangent_vector 
+        
+        return counterpart
 
     # Labelling and representation methods
     @property
@@ -421,39 +487,6 @@ class Connector(RigidlyTransformable):
     #     # return hash(self) == hash(other)
     #     return self.fungible_with(other)
     
-    # Copying and attr transfer methods
-    def individualize(self) -> dict[tuple[AttachmentLabel, AttachmentLabel], 'Connector']:
-        '''
-        Expand a Connector into a set of Connectors with identical properties but 
-        distinct, singletons linkables, one for each linkable in the original Connector
-        '''
-        indiv_conn_map = dict()
-        for anchor_label, linker_label in cartesian(self.anchor.attachables, self.linker.attachables):
-            conn_clone = self.copy()
-            conn_clone.anchor.attachment = anchor_label
-            conn_clone.anchor.attachables = {anchor_label}
-            
-            conn_clone.linker.attachment = linker_label
-            conn_clone.linker.attachables = {linker_label}
-
-            indiv_conn_map[(anchor_label, linker_label)] = conn_clone
-        return indiv_conn_map
-    
-    def counterpart(self) -> 'Connector':
-        '''
-        Create a counterpart Connector which is identical to this Connector but has its linker and anchor sites swapped
-        
-        By construction, the counterpart will always be bondable with this Connector (and vice versa),
-        assuming the attachables set of the anchor and linker point are both non-empty
-        '''
-        counterpart = self.copy()
-        counterpart.anchor, counterpart.linker = self.linker, self.anchor
-        if self.has_tangent_position:
-            # NOTE: since vector if defined by difference to tangent point, updated tangent 
-            # point can be set directly from this difference, since anchor is updated about
-            counterpart.tangent_vector = self.tangent_vector 
-        
-        return counterpart
 
 # Canonicalization
 def canonical_form_connectors(connectors: Iterable[Connector], separator : str=':', joiner : str='-') -> str:

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -531,7 +531,10 @@ class Connector(RigidlyTransformable):
         self._label = new_label
         
     def address(self) -> int:
-        '''Unique identifier used to identify this Connector instances, irrespective of similarity to other Connectors'''
+        '''
+        Unique identifier used to identify this Connector instances,
+        irrespective of similarity to other Connectors
+        '''
         return id(self)
     
     def canonical_form(self) -> BondType:

--- a/mupt/mupr/connection/connectors.py
+++ b/mupt/mupr/connection/connectors.py
@@ -1,4 +1,8 @@
-'''Abstractions of connections between two primitives'''
+'''
+Core components of connections, namely:
+* AttachmentPoints, which define geometric positions and selectivity of attachment sites
+* Connectors, which comprise 2 attachment points (an "anchor" and a "linker") and represent half of a chemical bond
+'''
 
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'
@@ -8,63 +12,31 @@ LOGGER = logging.getLogger(__name__)
 
 from typing import (
     Any,
-    Callable,
     ClassVar,
-    Collection,
     Generator,
     Hashable,
     Iterable,
-    Mapping,
     Optional,
-    Protocol,
-    TypeVar,
-    TypeAlias,
     Union,
 )
 from warnings import warn
 
 from dataclasses import dataclass, field
-from enum import Enum
 from copy import deepcopy
 from itertools import product as cartesian
 
 import numpy as np
 from scipy.spatial.transform import Rotation, RigidTransform
 
-from .canonicalize import lex_order_multiset_str
-from ..chemistry.core import BondType, BOND_ORDER
-from ..geometry.arraytypes import Shape, Vector3, Array3x3, as_n_vector, compare_optional_positions
-from ..geometry.measure import within_ball
-from ..geometry.coordinates.basis import is_orthonormal
-from ..geometry.transforms.linear import rejector
-from ..geometry.transforms.rigid.rotations import alignment_rotation
-from ..geometry.transforms.rigid.application import RigidlyTransformable
-
-
-# Label typehints
-type AttachmentLabel = Hashable  # TODO: narrow down this type as use cases become clearer
-type ConnectorLabel = Hashable
-ConnectorHandle = tuple[ConnectorLabel, int]
-
-ConnectorAddress = TypeVar('ConnectorAddress', bound=int)
-
-
-# Custom Exceptions
-class ConnectionError(Exception):
-    '''Raised when Connector-related errors as encountered'''
-    pass
-
-class IncompatibleConnectorError(ConnectionError):
-    '''Raised when attempting to connect two Connectors which are, for whatever reason, incompatible'''
-    pass
-
-class MissingConnectorError(ConnectionError):
-    '''Raised when a required Connector is missing'''
-    pass
-
-class UnboundConnectorError(ConnectionError):
-    '''Raised when a pair of Connectors are unexpectedly not bound to one another'''
-    pass
+from .types import AttachmentLabel, ConnectorLabel, ConnectorHandle
+from ..canonicalize import lex_order_multiset_str
+from ...chemistry.core import BondType, BOND_ORDER
+from ...geometry.arraytypes import Vector3, Array3x3, as_n_vector, compare_optional_positions
+from ...geometry.measure import within_ball
+from ...geometry.coordinates.basis import is_orthonormal
+from ...geometry.transforms.linear import rejector
+from ...geometry.transforms.rigid.rotations import alignment_rotation
+from ...geometry.transforms.rigid.application import RigidlyTransformable
 
 
 # DEV: would love to make this frozen, but that breaks the RigidlyTansformable mechanism under-the-hood,
@@ -121,6 +93,14 @@ class Connector(RigidlyTransformable):
         self.metadata = metadata or dict()
     
         self._tangent_position = None # DEV: no call to setter; must be assigned via protected tangent_vector property
+
+    @property
+    def bond_order(self) -> float:
+        '''
+        A numerical bond order corresponding to the type of bond this Connector is associated with
+        E.g. UNASSIGNED = 0.0, AROMATIC = 1.5, DOUBLE = 2.0, etc.
+        '''
+        return BOND_ORDER.get(self.bondtype, 0.0)
 
     # Geometric properties
     ## DEV: implemented vector properties (e.g. bond/tangent/normal) by tracking endpoint positions under the hood to get them to
@@ -623,28 +603,6 @@ class Connector(RigidlyTransformable):
         
         return counterpart
 
-## Selection between pairs of Connectors (useful, for example, for resolution-shift operations)
-ConnectorSelector : TypeAlias = Callable[[Connector, Connector], Connector]
-
-def select_first(connector1 : Connector, connector2 : Connector) -> Connector:
-    '''Select the first of a pair of Connectors'''
-    return connector1
-
-def select_second(connector1 : Connector, connector2 : Connector) -> Connector:
-    '''Select the second of a pair of Connectors'''
-    return connector2
-
-def make_second_resemble_first(connector1 : Connector, connector2 : Connector) -> Connector:
-    '''Select the first of a pair of Connectors, but merge their linkables'''
-    new_connector = connector2.copy()
-    new_connector.anchor.attachables.update(connector1.anchor.attachables)
-    new_connector.linker.attachables.update(connector1.linker.attachables)
-    
-    return new_connector
-
-# DEV: provide implementations which make some attempt to reconcile spatial info attache to respective Connectors
-...
-
 # Canonicalization
 def canonical_form_connectors(connectors: Iterable[Connector], separator : str=':', joiner : str='-') -> str:
     '''A hashable string representing a collection of Connectors in canonical form'''
@@ -654,36 +612,3 @@ def canonical_form_connectors(connectors: Iterable[Connector], separator : str='
         separator=separator,
         joiner=joiner,
     )
-
-class ManagesConnectors(Protocol):
-    '''Interface for objects which manage Connectors and pairs of Connectors ("connections")'''
-    connectors : Collection[Connector]
-    connectors_by_address : Mapping[ConnectorAddress, Connector]
-    
-    def connector(self, conn_addr : ConnectorAddress) -> Connector:
-        ...
-
-    @property
-    def connectors_free(self) -> Collection[Connector]:
-        '''Connectors which are currently unbound'''
-        ...
-
-    @property
-    def connectors_bound(self) -> Collection[Connector]:
-        '''Connectors which have a neighbor'''
-        ...
-
-    # default implementations, for when explicitly inherited
-    @property
-    def functionality(self) -> int:
-        return len(self.connectors_free)
-    
-    @property
-    def valence(self) -> int: # DEV: well-defined from more than just atomic primitives since Connectors store BondType info
-        '''Electronic valence of the Primitive, i.e. the total bond order of all external-facing Connectors on this Primitive'''
-        total_bond_order : float = sum(
-            BOND_ORDER.get(conn.bondtype, 0.0)
-                for conn in self.connectors
-        )
-        return round(total_bond_order)
-    chemical_valence = electronic_valence = valence # aliases for convenience

--- a/mupt/mupr/connection/exceptions.py
+++ b/mupt/mupr/connection/exceptions.py
@@ -1,0 +1,21 @@
+'''Exceptions specific to Connectors and related operations'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+
+class ConnectionError(Exception):
+    '''Raised when Connector-related errors as encountered'''
+    pass
+
+class IncompatibleConnectorError(ConnectionError):
+    '''Raised when attempting to connect two Connectors which are, for whatever reason, incompatible'''
+    pass
+
+class MissingConnectorError(ConnectionError):
+    '''Raised when a required Connector is missing'''
+    pass
+
+class UnboundConnectorError(ConnectionError):
+    '''Raised when a pair of Connectors are unexpectedly not bound to one another'''
+    pass

--- a/mupt/mupr/connection/types.py
+++ b/mupt/mupr/connection/types.py
@@ -1,0 +1,50 @@
+'''Typehints, alises, and Protocols relating to how connections are specified'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+from typing import (
+    Collection,
+    Hashable,
+    Mapping,
+    Protocol,
+    TypeVar,
+)
+from .connectors import Connector
+
+type AttachmentLabel = Hashable  # TODO: narrow down this type as use cases become clearer
+type ConnectorLabel = Hashable
+ConnectorHandle = tuple[ConnectorLabel, int]
+
+type ConnectorAddress = int # DEV TB: consider if this type needs to be more specific than just an alias
+
+
+class ManagesConnectors(Protocol):
+    '''Interface for objects which manage Connectors and pairs of Connectors ("connections")'''
+    connectors : Collection[Connector]
+    connectors_by_address : Mapping[ConnectorAddress, Connector]
+    
+    def connector(self, conn_addr : ConnectorAddress) -> Connector:
+        ...
+
+    @property
+    def connectors_free(self) -> Collection[Connector]:
+        '''Connectors which are currently unbound'''
+        ...
+
+    @property
+    def connectors_bound(self) -> Collection[Connector]:
+        '''Connectors which have a neighbor'''
+        ...
+
+    # default implementations, for when explicitly inherited
+    @property
+    def functionality(self) -> int:
+        return len(self.connectors_free)
+    
+    @property
+    def valence(self) -> int: # DEV: well-defined from more than just atomic primitives since Connectors store BondType info
+        '''Electronic valence of the Primitive, i.e. the total bond order of all external-facing Connectors on this Primitive'''
+        total_bond_order : float = sum(conn.bond_order for conn in self.connectors)
+        return round(total_bond_order)
+    chemical_valence = electronic_valence = valence # aliases for convenience

--- a/mupt/mupr/connection/types.py
+++ b/mupt/mupr/connection/types.py
@@ -1,4 +1,4 @@
-'''Typehints, alises, and Protocols relating to how connections are specified'''
+'''Typehints, aliases, and Protocols relating to how connections are specified'''
 
 __author__ = 'Timotej Bernat'
 __email__ = 'timotej.bernat@colorado.edu'

--- a/mupt/mupr/connection/types.py
+++ b/mupt/mupr/connection/types.py
@@ -8,9 +8,10 @@ from typing import (
     Hashable,
     Mapping,
     Protocol,
-    TypeVar,
+    TYPE_CHECKING,
 )
-from .connectors import Connector
+if TYPE_CHECKING:
+    from .connectors import Connector
 
 type AttachmentLabel = Hashable  # TODO: narrow down this type as use cases become clearer
 type ConnectorLabel = Hashable
@@ -21,19 +22,19 @@ type ConnectorAddress = int # DEV TB: consider if this type needs to be more spe
 
 class ManagesConnectors(Protocol):
     '''Interface for objects which manage Connectors and pairs of Connectors ("connections")'''
-    connectors : Collection[Connector]
-    connectors_by_address : Mapping[ConnectorAddress, Connector]
+    connectors : Collection['Connector']
+    connectors_by_address : Mapping[ConnectorAddress, 'Connector']
     
-    def connector(self, conn_addr : ConnectorAddress) -> Connector:
+    def connector(self, conn_addr : ConnectorAddress) -> 'Connector':
         ...
 
     @property
-    def connectors_free(self) -> Collection[Connector]:
+    def connectors_free(self) -> Collection['Connector']:
         '''Connectors which are currently unbound'''
         ...
 
     @property
-    def connectors_bound(self) -> Collection[Connector]:
+    def connectors_bound(self) -> Collection['Connector']:
         '''Connectors which have a neighbor'''
         ...
 

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -34,7 +34,6 @@ from scipy.spatial.transform import RigidTransform
 from .canonicalize import lex_order_multiset_str
 from .connection import (
     Connector,
-    make_second_resemble_first,
     canonical_form_connectors,
     IncompatibleConnectorError,
     MissingConnectorError,
@@ -51,7 +50,7 @@ from ..geometry.transforms.rigid import RigidlyTransformable
 from ..chemistry.core import ElementLike, isatom, valence_allowed
 
 ConnectionReference = tuple[PrimitiveAddress, ConnectorAddress]
-Connection = AbstractSet[ConnectionReference, ConnectionReference] # using set, rather than tuple, to avoid order-dependence
+Connection = AbstractSet[ConnectionReference] # of size 2; using set, rather than tuple, to avoid order-dependence
 
 
 # Custom Exceptions
@@ -74,11 +73,10 @@ class BijectionError(ValueError):
     
 # Primitive types        
 class Primitive(
-    NodeMixin,
     Shaped,
     RigidlyTransformable,
     ManagesConnectors,
-    Protocol,
+    NodeMixin,
 ):
     '''
     A fundamental, scale-agnostic building block of a molecular system, as represented my MuPT
@@ -306,7 +304,6 @@ class FrozenCompositePrimitive(CompositePrimitive):
         self,
         children : UniqueRegistry[PrimitiveHandle, Primitive],
         connections : Iterable[Connection],
-        topology : nx.Graph,
         shape : Optional[BoundedTransformableShape]=None,
         metadata : Optional[dict]=None, 
     ):
@@ -460,7 +457,6 @@ class MutableCompositePrimitive(CompositePrimitive): # DEV: this will behave by 
     ) -> None:
         raise NotImplementedError
 
-
     # Resolution shift operations
     def expand(self, target : PrimitiveHandle) -> None:
         '''Replace a child Primitive with its children, preserving connections and traces'''
@@ -470,12 +466,12 @@ class MutableCompositePrimitive(CompositePrimitive): # DEV: this will behave by 
         '''Recursively expand until all childless subprimitives are depth 1 below this one'''
         raise NotImplementedError
 
-    def contract(self, parts : Iterable[AbstractSet[PrimitiveHandle]], implcit_parts : bool=True) -> None:
+    def contract(self, parts : Iterable[AbstractSet[PrimitiveHandle]], implicit_parts : bool=True) -> None:
         '''
         Insert a new level of Primitive between this Composite and its children,
         with each part of the provided partition forming a new child Primitive
         
-        Behavior of implcit parts (i.e. any not explicitly mentioned in "parts") can be specified via the "implicit_parts" argument
+        Behavior of implicit parts (i.e. any not explicitly mentioned in "parts") can be specified via the "implicit_parts" argument
         ''' # DEV: eventually, make enum for implicit_parts behavior
         raise NotImplementedError
 

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -99,7 +99,7 @@ class Primitive(
     def address(self) -> int:
         '''
         Unique identifier used to identify this Primitive instance,
-        irrespective of similarity to other Connectors
+        irrespective of similarity to other Primitives
         '''
         return id(self)
 

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -79,7 +79,7 @@ class Primitive(
     NodeMixin,
 ):
     '''
-    A fundamental, scale-agnostic building block of a molecular system, as represented my MuPT
+    Base class for fundamental, scale-agnostic building block of a molecular system
     '''
     # Attributes
     ## Classwide defaults
@@ -113,12 +113,12 @@ class Primitive(
             connector.rigidly_transform(transformation)
 
     # Topology
-    def connector_trace(self, conn_addr : ConnectorAddress) -> Iterable['ManagesConnectors']:
-        ...
-
-    def neighbors(self) -> Iterable['Primitive']:
-        ''''''
-        ...
+    def neighbors(self, criterion : Callable[['Primitive'], bool]) -> Iterable['Primitive']:
+        '''Primitives on the other end of a bound Connector, selected at the target level of resolution'''
+        for conn in self.connectors_bound: # inherited from ManagesConnectors contract
+            for nb_primitive in conn.managers:
+                if criterion(nb_primitive): # TB DEV: criterion Callable is not Covariant, gives type error
+                    return nb_primitive # TB DEV: opting for return over yield to take first - this may change later
 
     # Depiction
     ## Hashable canonical forms for core components
@@ -153,11 +153,8 @@ class Primitive(
     # def __repr__(self) -> str:
     #     raise NotImplementedError # TODO - will likely have to change for subtypes
     
-    
-## Simples
-TRIVIAL_TOPOLOGY = nx.Graph()
-nx.freeze(TRIVIAL_TOPOLOGY) # VITAL that this be frozen to allow it to act as shared singleton across Simples
 
+## Simples
 class SimplePrimitive(Primitive):
     '''
     A Primitive with no internal structure (i.e. no children, topology, or internal connections)
@@ -176,7 +173,6 @@ class SimplePrimitive(Primitive):
             id(conn) : conn
                 for conn in self.connectors # NOTE: not iterating over connectors directly in case it was an Iterator which was exhausted during self.connectors assignment
         }
-        self.topology = TRIVIAL_TOPOLOGY # trivial topology for simples - "calling card" for an eventual canonical graph form
         self._shape = shape
         self.metadata = metadata or dict()
     
@@ -226,14 +222,14 @@ class AtomicPrimitive(SimplePrimitive):
         )
 
     @property # DEV: no setter implemented; element is immutable after instantiation
-    def element(self) -> Optional[ElementLike]:
+    def element(self) -> ElementLike:
         '''The chemical element, ion, or isotope associated with this AtomicPrimitive'''
         return self._element
     
     def check_valence(self) -> None:
         '''Check that element assigned to atomic Primitives and bond orders of Connectors are chemically-compatible'''
         if not valence_allowed(self.element.number, self.element.charge, self.valence):
-            raise ValueError(f'Atomic {self._repr_brief(include_functionality=True)} with total valence {self.valence} incompatible with assigned element {self.element!r}')
+            raise ValueError(f'Atomic {self!r} with total valence {self.valence} incompatible with assigned element {self.element!r}')
     
     def canonical_form(self):
         return f'{self.element.symbol}{super().canonical_form()}'
@@ -248,7 +244,7 @@ class CompositePrimitive(Primitive):
 
     CompositePrimitives form the branches of the a representation hierarchy tree
     '''
-    DEFAULT_LABEL : ClassVar[PrimitiveLabel] = 'TREE'
+    DEFAULT_LABEL : ClassVar[PrimitiveLabel] = 'COMPOSITE'
     
     internal_connector_addrs : Collection[ConnectorAddress]
     external_connector_addrs : Collection[ConnectorAddress]
@@ -327,9 +323,9 @@ class FrozenCompositePrimitive(CompositePrimitive):
         self._external_connector_addresses : set[ConnectorAddress] = all_connector_addresses - self._internal_connector_addresses # guaranteed valid by above precondition
         
         # Validate and set topology
-        check_primitive_registry_bijective_to_topology_nodes(children, topology)
-        check_connections_bijective_to_topology_edges(connections, topology)
-        self._topology = topology # call validator on first-time pass
+        # check_primitive_registry_bijective_to_topology_nodes(children, topology)
+        # check_connections_bijective_to_topology_edges(connections, topology)
+        # self._topology = topology # call validator on first-time pass
         
         # Initialization proper
         self.children_by_handle = children
@@ -351,8 +347,10 @@ class FrozenCompositePrimitive(CompositePrimitive):
         
 class MutableCompositePrimitive(CompositePrimitive): # DEV: this will behave by far the closest to the current Primitive impl
     '''
-    A CompositePrimitive which allows for dynamic modification of its internal structure
-    (i.e. adding/removing children and connections at will)
+    A CompositePrimitive which allows for dynamic modification of its internal
+    structure (i.e. adding/removing children and connections at will)
+
+    Used for assembling and connecting systems
     '''
     def __init__( # DEV: could omit entirely; repeated for documentation purposes, and in case extra init config needs to be addeds
         self,

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -29,7 +29,6 @@ from anytree import NodeMixin, findall
 import networkx as nx
 from scipy.spatial.transform import RigidTransform
 
-from .canonicalize import lex_order_multiset_str
 from .connection import (
     Connector,
     canonical_form_connectors,
@@ -551,18 +550,6 @@ def check_connections_bijective_to_topology_edges(
         )
 
 # Hashable canonical forms for core components
-def canonical_form_connectors(
-    primitive : Primitive,
-    separator : str=':',
-    joiner : str='-',
-) -> str:
-    '''A canonical string representing this Primitive's Connectors'''
-    return canonical_form_connectors(
-        sorted(primitive.connectors),
-        separator=separator,
-        joiner=joiner,
-    )
-
 def canonical_form_shape(primitive : Primitive) -> str:
     '''A canonical string representing this Primitive's shape'''
     return type(primitive.shape).__name__ # TODO: move this into .shape - should be responsibility of individual Shape subclasses

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -97,7 +97,10 @@ class Primitive(
         return self.DEFAULT_LABEL
     
     def address(self) -> int:
-        '''Unique identifier used to identify this Connector instances, irrespective of similarity to other Connectors'''
+        '''
+        Unique identifier used to identify this Primitive instance,
+        irrespective of similarity to other Connectors
+        '''
         return id(self)
 
     # Geometry

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -1061,7 +1061,7 @@ class Primitive(NodeMixin, RigidlyTransformable):
     def _copy_untransformed(self) -> 'Primitive':
         '''Return a new Primitive with the same information and children as this one, but which has no parent'''
         clone_primitive = self.__class__(
-            shape=(None if self.shape is None else self.shape.copy()), # DEV TODO: should be _copy_untransformed()?
+            shape=self.shape, # handles unset NoneType case natively
             element=self.element,
             # NOTE: connectors and children transferred verbatim below - no need to set in init here
             connectors=None, 

--- a/mupt/tests/geometry/test_arraytypes.py
+++ b/mupt/tests/geometry/test_arraytypes.py
@@ -1,0 +1,50 @@
+'''Unit tests for array size and dtype typehinting'''
+
+__author__ = 'Timotej Bernat'
+__email__ = 'timotej.bernat@colorado.edu'
+
+import pytest
+import numpy as np
+
+from mupt.geometry.arraytypes import (
+    as_n_vector,
+    VectorN,
+)
+
+
+@pytest.fixture
+def vector_expected() -> VectorN:
+    return np.array([1.,2.,3.])
+
+@pytest.mark.parametrize(
+    'vectorlike',
+    [
+        ([1,2,3]),
+        [[1,2,3]],
+        tuple([1,2,3]),
+        np.array([1,2,3]),
+        np.array([1.,2.,3.]),
+        np.array([[1,2,3]]),
+        np.array([[1,2,3]]).T,
+        pytest.param(
+            [1,2,3,4],
+            marks=pytest.mark.xfail(
+                raises=AssertionError,
+                reason='Input vectorlike has the wrong shape',
+                strict=True,
+            )
+        ),
+        pytest.param(
+            '[1,2,3]',
+            marks=pytest.mark.xfail(
+                raises=TypeError,
+                reason='String of numerics is not a valid Sequence of numerics for interpretation as a vector',
+                strict=True,
+            )
+        ),
+    ],
+)
+def test_as_n_vector_shape(vectorlike, vector_expected : VectorN) -> None:
+    '''Test that permissive vector ingestion accepts the kinds of numeric data structures it advertises'''
+    vector_actual = as_n_vector(vectorlike, dimension=None) # suppress internal shape validation
+    assert (vector_actual.size == (vector_expected.size))

--- a/mupt/tests/geometry/test_arraytypes.py
+++ b/mupt/tests/geometry/test_arraytypes.py
@@ -1,0 +1,47 @@
+'''Unit tests for array size and dtype typehinting'''
+
+import pytest
+import numpy as np
+
+from mupt.geometry.arraytypes import (
+    as_n_vector,
+    VectorN,
+)
+
+
+@pytest.fixture
+def vector_expected() -> VectorN:
+    return np.array([1.,2.,3.])
+
+@pytest.mark.parametrize(
+    'vectorlike',
+    [
+        ([1,2,3]),
+        [[1,2,3]],
+        tuple([1,2,3]),
+        np.array([1,2,3]),
+        np.array([1.,2.,3.]),
+        np.array([[1,2,3]]),
+        np.array([[1,2,3]]).T,
+        pytest.param(
+            [1,2,3,4],
+            marks=pytest.mark.xfail(
+                raises=AssertionError,
+                reason='Input vectorlike has the wrong shape',
+                strict=True,
+            )
+        ),
+        pytest.param(
+            '[1,2,3]',
+            marks=pytest.mark.xfail(
+                raises=TypeError,
+                reason='String of numerics is not a valid Sequence of numerics for interpretation as a vector',
+                strict=True,
+            )
+        ),
+    ],
+)
+def test_as_n_vector_shape(vectorlike, vector_expected : VectorN) -> None:
+    '''Test that permissive vector ingestion accepts the kinds of numeric data structures it advertises'''
+    vector_actual = as_n_vector(vectorlike, dimension=None) # suppress internal shape validation
+    assert (vector_actual.size == (vector_expected.size))

--- a/mupt/tests/geometry/test_shapes.py
+++ b/mupt/tests/geometry/test_shapes.py
@@ -34,7 +34,7 @@ def shapes() -> list[BoundedTransformableShape]:
 def shapes_transformed() -> list[BoundedTransformableShape]:
     '''Transformed versions of the sample test BoundedTransformableShape instances returned by `shapes()`'''
     return [
-        shape.rigidly_transformed(random_rigid_transformation())
+        shape.rigidly_transformed(random_rigid_transformation(translation_bound=1.0))
             for shape in shapes()
     ]
 
@@ -147,7 +147,7 @@ def test_equality(shape : BoundedTransformableShape) -> None:
 @pytest.mark.parametrize('shape,volume_expected', shapes_with_volumes())
 def test_volume_transformed(shape : BoundedTransformableShape, volume_expected : float) -> None:
     '''Test that volume calculations remain invariant under rigid transformations'''
-    shape_transformed = shape.rigidly_transformed(random_rigid_transformation())
+    shape_transformed = shape.rigidly_transformed(random_rigid_transformation(translation_bound=1.0))
     nptest.assert_allclose(shape_transformed.volume, volume_expected) # rigid motions have unit determinant and shouldn't affect volumes
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Extends data stored on Connector to enable more complex resolution shift and topology collection on refactor of Primitives

## Todos
Notable points that this PR has either accomplished or will accomplish:
  - [x] Break apart `mupt.mupr.connection` into smaller, more cohesive submodules
  - [x] Add `neighbor` descriptor for binding one Connector to another
    - [x] Add Requisite getters and setters
  - [x] Add (implicit) parents collection
    - [x] Add ability to remove Primitives as parent(s) from without (not within) the Connector API

## Questions
- [ ] How should parents be sorted without reliance on implementation details of Primitive? Would be most natural to sort by depth in tree
- [ ] Should query_smarts just be moved into metadata?

## Status
- [ ] Pass tests
- [ ] Obtain review
- [ ] Merge into `prim-refactor` **feature** branch (NOT `main`)