### PR TITLE
Fully-featured Primitive resolution shift operations

### DIFF
--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -460,7 +460,6 @@ class MutableCompositePrimitive(CompositePrimitive): # DEV: this will behave by 
     ) -> None:
         raise NotImplementedError
 
-
     # Resolution shift operations
     def expand(self, target : PrimitiveHandle) -> None:
         '''Replace a child Primitive with its children, preserving connections and traces'''
@@ -483,7 +482,7 @@ class MutableCompositePrimitive(CompositePrimitive): # DEV: this will behave by 
         '''Replace a child Primitive with an analogous SimplePrimitive, effectively severing all internal structure beneath it'''
         raise NotImplementedError
     
-    def freeze(self) -> FrozenCompositePrimitive:
+    def frozen(self) -> FrozenCompositePrimitive:
         '''
         Return an immutable CompositePrimitive copy of this MutableCompositePrimitive
         '''

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -469,16 +469,16 @@ class MutableCompositePrimitive(CompositePrimitive): # DEV: this will behave by 
         '''Recursively expand until all childless subprimitives are depth 1 below this one'''
         raise NotImplementedError
 
-    def contract(self, parts : Iterable[AbstractSet[PrimitiveHandle]], implcit_parts : bool=True) -> None:
+    def retract(self, parts : Iterable[AbstractSet[PrimitiveHandle]], implicit_parts : bool=True) -> None:
         '''
         Insert a new level of Primitive between this Composite and its children,
         with each part of the provided partition forming a new child Primitive
         
-        Behavior of implcit parts (i.e. any not explicitly mentioned in "parts") can be specified via the "implicit_parts" argument
+        Behavior of implicit parts (i.e. any not explicitly mentioned in "parts") can be specified via the "implicit_parts" argument
         ''' # DEV: eventually, make enum for implicit_parts behavior
         raise NotImplementedError
 
-    def cauterize(self, target : PrimitiveHandle) -> None:
+    def truncate(self, target : PrimitiveHandle) -> None:
         '''Replace a child Primitive with an analogous SimplePrimitive, effectively severing all internal structure beneath it'''
         raise NotImplementedError
     

--- a/mupt/mupr/primitives.py
+++ b/mupt/mupr/primitives.py
@@ -385,6 +385,7 @@ class SupportsChildren(Primitive):
         '''
         self._precondition_mutable_hierarchy()
         raise NotImplementedError
+    
 
     # Geometry
     ## Overriding RigidlyTransformable contracts - apply recursively to children as well


### PR DESCRIPTION
## Description
System preparation at arbitrary resolution scales and and CG backmap operations would greatly benefit from mature capability for expanding, retracting, and truncating intermediate scale Primitive within a hierarchy tree. Further, the implementation of expansion provided there is poorly-scalable, taking significant time even for systems on the order of 10k atoms, due to reliance on atomic operations on individual primitives, rather than caching information and making use of larger organizational units within the representation (i.e. avoiding the "deregister -> reregister/relabel -> reconnect to neighbors" path taken now). This was a deliberate choice to facilitate reasoning about the correctness of the program and simplify implementation, but would benefit from more targeted optimization now that it has been [tested in example workflows.](https://github.com/MuPT-hub/mupt-examples/blob/updates/examples_system/multiscale_chain_placement.ipynb)

## Todos
Notable points that this PR has either accomplished or will accomplish.
 - [ ] Implement resolution-shifting operation on mutable Composite Primitives, namely:
   - [ ] Implement `Primitive.retract()`: injects an intermediate level into a hierarchy between a parent Primitive and its children, encoding a partition of those children
     - [ ] Add support for MultiGraphs when collection topologies to ensure partitions w/ interlinked parts are supported, as well as allowing polymers with intrinsically multi-bonded repeat units, such as PIMs and polycyclophanes, to be represented
   - [ ] Implement `Primitive.truncate()`: add the ability to remove all levels below a given _Composite_ and replace it with an analogous Simple
  - [ ] Accelerate the implementation of (already-extant) `Primitive.expand()`
    - [ ] Implement native API for reassigning (still unique!) handles to children without de- and then re-registering them
    - [ ] Replace calls to `Primitive.flatten()` in exporters with topolgoy collection logic (_TB: likely an entirely separate PR_)
  - [ ] Implement total hierarchy-wide label uniquification in [tree rendering](https://anytree.readthedocs.io/en/latest/api/anytree.render.html) (not directly relevant, but would be enabled by the same kind of tree-wde handle uniquification required for the above)

## Questions
- [ ] _placeholder_

## Status
- [ ] Passed tests
- [ ] Passed co-dev review
  - [ ] Passed Copilot review to catch dumb spelling errors etc.
- [ ] Ready to go