### PR TITLE
Pin Python below 3.14 to resolve OpenFF-related CI failures 

### DIFF
--- a/devtools/conda-envs/dev-env.yml
+++ b/devtools/conda-envs/dev-env.yml
@@ -4,9 +4,7 @@ channels:
   - defaults
 dependencies:
   # Basic Python dependencies
-  ## pinned Python under 3.14 to avoid pydantic/openff units issues
-  ## documented here: https://github.com/openforcefield/openff-units/pull/178
-  - python>=3.12,<3.14 
+  - python>=3.12,<3.14  # <3.14 because of https://github.com/openforcefield/openff-units/pull/178
   - pip
   - jupyterlab
 

--- a/devtools/conda-envs/dev-env.yml
+++ b/devtools/conda-envs/dev-env.yml
@@ -3,48 +3,48 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-    # Basic Python dependencies
-    ## pinned Python under 3.14 to avoid pydantic/openff units issues
-    ## documented here: https://github.com/openforcefield/openff-units/pull/178
-    - python>=3.12,<3.14 
-    - pip
-    - jupyterlab
+  # Basic Python dependencies
+  ## pinned Python under 3.14 to avoid pydantic/openff units issues
+  ## documented here: https://github.com/openforcefield/openff-units/pull/178
+  - python>=3.12,<3.14 
+  - pip
+  - jupyterlab
 
-    # Unit testing
-    - pytest
-    - pytest-cov
-    - codecov
-    - nbval
+  # Unit testing
+  - pytest
+  - pytest-cov
+  - codecov
+  - nbval
 
-    # Mathematics and scientific computing
-    - numpy
-    - scipy>=1.16.0 # required to allow use of RigidTransform
-    - sympy
+  # Mathematics and scientific computing
+  - numpy
+  - scipy>=1.16.0 # required to allow use of RigidTransform
+  - sympy
 
-    # Graphs
-    - anytree
-    - networkx
+  # Graphs
+  - anytree
+  - networkx
 
-    # Visualization
-    - rich
-    - matplotlib
-    - ipympl
+  # Visualization
+  - rich
+  - matplotlib
+  - ipympl
 
-    # Molecular libraries
-    - rdkit
-    - py3Dmol
-    - openbabel>=3.0
-    - mbuild >=1.0
-    - periodictable
+  # Molecular libraries
+  - rdkit
+  - py3Dmol
+  - openbabel>=3.0
+  - mbuild >=1.0
+  - periodictable
 
-    # MD libraries
-    - openff-toolkit
-    - openff-interchange
-    - gsd>=3.0
-    - hoomd=5.3.0
-    - freud=3.0
-    # - fresnel
+  # MD libraries
+  - openff-toolkit
+  - openff-interchange
+  - gsd>=3.0
+  - hoomd=5.3.0
+  - freud=3.0
+  # - fresnel
 
-    - pip:
-      - build
-        # - some_pypi_module_name
+  - pip:
+    - build
+      # - some_pypi_module_name

--- a/devtools/conda-envs/dev-env.yml
+++ b/devtools/conda-envs/dev-env.yml
@@ -4,7 +4,9 @@ channels:
   - defaults
 dependencies:
     # Basic Python dependencies
-    - python>=3.12
+    ## pinned Python under 3.14 to avoid pydantic/openff units issues
+    ## documented here: https://github.com/openforcefield/openff-units/pull/178
+    - python>=3.12,<3.14 
     - pip
     - jupyterlab
 

--- a/devtools/conda-envs/light-env.yml
+++ b/devtools/conda-envs/light-env.yml
@@ -3,36 +3,36 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-    # Basic Python dependencies
-    ## pinned Python under 3.14 to avoid pydantic/openff units issues
-    ## documented here: https://github.com/openforcefield/openff-units/pull/178
-    - python>=3.12,<3.14 
-    - pip
-    - rich
+  # Basic Python dependencies
+  ## pinned Python under 3.14 to avoid pydantic/openff units issues
+  ## documented here: https://github.com/openforcefield/openff-units/pull/178
+  - python>=3.12,<3.14 
+  - pip
+  - rich
 
-    # Unit testing
-    - pytest
-    - pytest-cov
-    - codecov
-    - nbval
+  # Unit testing
+  - pytest
+  - pytest-cov
+  - codecov
+  - nbval
 
-    # Visualization
-    - matplotlib
-    - jupyterlab
-    - ipympl
+  # Visualization
+  - matplotlib
+  - jupyterlab
+  - ipympl
 
-    # Scientific computing
-    - numpy>=2.0
-    - scipy>=1.16.0 # version pin required to allow use of RigidTransform
-    - sympy
+  # Scientific computing
+  - numpy>=2.0
+  - scipy>=1.16.0 # version pin required to allow use of RigidTransform
+  - sympy
 
-    # Graphs
-    - anytree
-    - networkx
+  # Graphs
+  - anytree
+  - networkx
 
-    # Molecular libraries
-    - rdkit
-    - periodictable
+  # Molecular libraries
+  - rdkit
+  - periodictable
 
-    # - pip:
-        # - some_pypi_module_name
+  # - pip:
+      # - some_pypi_module_name

--- a/devtools/conda-envs/light-env.yml
+++ b/devtools/conda-envs/light-env.yml
@@ -4,7 +4,9 @@ channels:
   - defaults
 dependencies:
     # Basic Python dependencies
-    - python>=3.12
+    ## pinned Python under 3.14 to avoid pydantic/openff units issues
+    ## documented here: https://github.com/openforcefield/openff-units/pull/178
+    - python>=3.12,<3.14 
     - pip
     - rich
 

--- a/devtools/conda-envs/light-env.yml
+++ b/devtools/conda-envs/light-env.yml
@@ -4,9 +4,7 @@ channels:
   - defaults
 dependencies:
   # Basic Python dependencies
-  ## pinned Python under 3.14 to avoid pydantic/openff units issues
-  ## documented here: https://github.com/openforcefield/openff-units/pull/178
-  - python>=3.12,<3.14 
+  - python>=3.12,<3.14  # <3.14 because of https://github.com/openforcefield/openff-units/pull/178
   - pip
   - rich
 

--- a/devtools/conda-envs/release-env.yml
+++ b/devtools/conda-envs/release-env.yml
@@ -4,9 +4,7 @@ channels:
   - defaults
 dependencies:
   # Basic Python dependencies
-  ## pinned Python under 3.14 to avoid pydantic/openff units issues
-  ## documented here: https://github.com/openforcefield/openff-units/pull/178
-  - python>=3.12,<3.14 
+  - python>=3.12,<3.14  # <3.14 because of https://github.com/openforcefield/openff-units/pull/178
   - pip
   - jupyterlab
 

--- a/devtools/conda-envs/release-env.yml
+++ b/devtools/conda-envs/release-env.yml
@@ -4,8 +4,9 @@ channels:
   - defaults
 dependencies:
     # Basic Python dependencies
-    # - python>=3.12
-    - python
+    ## pinned Python under 3.14 to avoid pydantic/openff units issues
+    ## documented here: https://github.com/openforcefield/openff-units/pull/178
+    - python>=3.12,<3.14 
     - pip
     - jupyterlab
 

--- a/devtools/conda-envs/release-env.yml
+++ b/devtools/conda-envs/release-env.yml
@@ -3,53 +3,53 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-    # Basic Python dependencies
-    ## pinned Python under 3.14 to avoid pydantic/openff units issues
-    ## documented here: https://github.com/openforcefield/openff-units/pull/178
-    - python>=3.12,<3.14 
-    - pip
-    - jupyterlab
+  # Basic Python dependencies
+  ## pinned Python under 3.14 to avoid pydantic/openff units issues
+  ## documented here: https://github.com/openforcefield/openff-units/pull/178
+  - python>=3.12,<3.14 
+  - pip
+  - jupyterlab
 
-    # Unit testing
-    - pytest
-    - pytest-cov
-    - codecov
-    - nbval
+  # Unit testing
+  - pytest
+  - pytest-cov
+  - codecov
+  - nbval
 
-    # Mathematics and scientific computing
-    # - numpy>=2.0
-    - numpy
-    - scipy>=1.16.0 # required to allow use of RigidTransform
-    - sympy
+  # Mathematics and scientific computing
+  # - numpy>=2.0
+  - numpy
+  - scipy>=1.16.0 # required to allow use of RigidTransform
+  - sympy
 
-    # Graphs
-    - anytree
-    - networkx
+  # Graphs
+  - anytree
+  - networkx
 
-    # Visualization
-    - rich
-    - matplotlib
-    - ipympl
+  # Visualization
+  - rich
+  - matplotlib
+  - ipympl
 
-    # Chemistry
-    - rdkit
-    - periodictable
+  # Chemistry
+  - rdkit
+  - periodictable
 
-    # Molecular Dynamics toolkits
-    ## OpenFF
-    - openff-toolkit
-    - openff-interchange
-    - mdanalysis
+  # Molecular Dynamics toolkits
+  ## OpenFF
+  - openff-toolkit
+  - openff-interchange
+  - mdanalysis
 
-    ## HOOMD
-    - hoomd
-    - gsd
-    - freud
-    - fresnel
+  ## HOOMD
+  - hoomd
+  - gsd
+  - freud
+  - fresnel
 
-    ## MoSDeF
-    # - mbuild # DEV: dependencies and env solve really don't play nice w/ OpenFF - hiding for now, since unused in code + examples
-    - gmso
+  ## MoSDeF
+  # - mbuild # DEV: dependencies and env solve really don't play nice w/ OpenFF - hiding for now, since unused in code + examples
+  - gmso
 
-    # - pip:
-        # - some_pypi_module_name
+  # - pip:
+      # - some_pypi_module_name

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -3,8 +3,10 @@ channels:
 
   - defaults
 dependencies:
-    # Base depends
-  - python
+  # Base depends
+  ## pinned Python under 3.14 to avoid pydantic/openff units issues
+  ## documented here: https://github.com/openforcefield/openff-units/pull/178
+  - python>=3.12,<3.14 
   - pip
 
     # Testing

--- a/devtools/conda-envs/test-env.yaml
+++ b/devtools/conda-envs/test-env.yaml
@@ -4,9 +4,7 @@ channels:
   - defaults
 dependencies:
   # Base depends
-  ## pinned Python under 3.14 to avoid pydantic/openff units issues
-  ## documented here: https://github.com/openforcefield/openff-units/pull/178
-  - python>=3.12,<3.14 
+  - python>=3.12,<3.14  # <3.14 because of https://github.com/openforcefield/openff-units/pull/178
   - pip
 
     # Testing


### PR DESCRIPTION
## Description
This PR is a quick resolution to the repo-wide [CI failures](https://github.com/MuPT-hub/mupt/actions/runs/28128905233) (beginning between 06/20 to 06/23) due to type errors caused by the interaction of Pydantic and openff.units within the `openff-toolkit`, as referenced in [this PR](https://github.com/openforcefield/openff-units/pull/178).

Directly from the OpenFF maintainers:
> Matt Thompson: 
_Pydantic 2.12 broke our ecosystem a few months ago and we've been (successfully!) down-pinning against it since then. The fulcrum of failure is combining openff.toolkit.Quantity with pydantic.BaseModel, which ends up with verbose and somewhat cryptic errors from Pydantic about arbitrary types not being allowed and/or schema not being defined on the Quantity class._
_I have drafts of changes that will get our software working on 2.12+, which I hope to release early in July. If this sounds like it impacts you, please test my changes by installing against the two PRs below. An example of how to do this in conda environments can be found [here](https://github.com/openforcefield/status/pull/147/changes). (So far, our ecosystem-level tests have not given us surprises!)_

> Mike Henry:
 _I wouldn't try using openff-toolkit with python 3.14 right now
The issue is probably some missing from __future__ import annotations in the source code if you do want to hack on it
We have a bootstrapping problem with python 3.14 support, it is hard for us to test it and support it when our dependencies don't support python 3.14, so when support starts getting unblocked then we can start fixing it and supporting it._

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Update all shipped conda envs to pin Python >=3.12,<3.14
  - [x] Fix repo-wide CI failures on notebook examples
 
## Status
- [x]  Update conda env YAMLs
- [ ] Verify this change permits nbval notebook tests to pass again
- [x] Resolve [examples #25](https://github.com/MuPT-hub/mupt-examples/pull/25#event-27225067401) 