### PR TITLE
Supply mixin for boilerplate object addressing

### DIFF
--- a/mupt/mutils/referencing.py
+++ b/mupt/mutils/referencing.py
@@ -1,0 +1,37 @@
+'''Utilities for providing Hashable references to arbitrary objects, along with registries of those objects'''
+
+from typing import ClassVar
+from uuid import UUID, uuid4
+from weakref import WeakValueDictionary
+
+
+class Addressable:
+    '''Boilerplate for objects which are assigned a universally-unique ID at initialization'''
+    registry_addresses : ClassVar[WeakValueDictionary[str, 'Addressable']]
+    
+    def __init_subclass__(cls, /,  **kwargs) -> None:
+        super(cls).__init_subclass__(**kwargs)
+        cls.registry_addresses = WeakValueDictionary() # avoids sharing mutable registry with subclasses 
+
+    # Object attr declarations
+    _uuid : UUID
+    _address : str
+
+    # def __init__(self) -> None:
+    def __new__(cls, *args, **kwargs) -> 'Addressable':
+        obj = super(Addressable, cls).__new__(cls)
+
+        unique_id = uuid4()
+        obj._uuid = unique_id
+        obj._address = unique_id.hex # opting for str conversion to avoid consumers needing to know about UUID type
+
+        cls.registry_addresses[obj._address] = obj
+
+        return obj
+
+    # NOT the same as __hash__ (instances with the same hash will have different addresses)
+    @property # protected, i.e. setter or deleter deliberately NOT offered
+    def address(self) -> str: 
+        '''Hashable hexademical string address unique to this object instance'''
+        return self._address
+    addr = address # alias for convenience

--- a/mupt/mutils/referencing.py
+++ b/mupt/mutils/referencing.py
@@ -38,6 +38,6 @@ class Addressed:
     # NOT the same as __hash__ (instances with the same hash will have different addresses)
     @property # protected, i.e. setter or deleter deliberately NOT offered
     def address(self) -> str: 
-        '''Hashable hexademical string address unique to this object instance'''
+        '''Hashable hexadecimal string address unique to this object instance'''
         return self._address
     addr = address # alias for convenience

--- a/mupt/mutils/referencing.py
+++ b/mupt/mutils/referencing.py
@@ -5,9 +5,9 @@ from uuid import UUID, uuid4
 from weakref import WeakValueDictionary
 
 
-class Addressable:
+class Addressed:
     '''Boilerplate for objects which are assigned a universally-unique ID at initialization'''
-    registry_addresses : ClassVar[WeakValueDictionary[str, 'Addressable']]
+    registry_addresses : ClassVar[WeakValueDictionary[str, 'Addressed']]
     
     def __init_subclass__(cls, /,  **kwargs) -> None:
         super(cls).__init_subclass__(**kwargs)
@@ -17,9 +17,8 @@ class Addressable:
     _uuid : UUID
     _address : str
 
-    # def __init__(self) -> None:
-    def __new__(cls, *args, **kwargs) -> 'Addressable':
-        obj = super(Addressable, cls).__new__(cls)
+    def __new__(cls, *args, **kwargs) -> 'Addressed':
+        obj = super(Addressed, cls).__new__(cls)
 
         unique_id = uuid4()
         obj._uuid = unique_id

--- a/mupt/mutils/referencing.py
+++ b/mupt/mutils/referencing.py
@@ -13,11 +13,14 @@ class Addressable(Protocol):
     address : str
 
 class Addressed:
-    '''Boilerplate for objects which are assigned a universally-unique ID at initialization'''
+    '''
+    Boilerplate mixin for objects which are assigned a unique, hashable address at initialization
+    Objects are also registered to a subclass-wide registry ("registry_addressed") keyed by their addresses
+    '''
     registry_addresses : ClassVar[WeakValueDictionary[str, 'Addressed']]
     
     def __init_subclass__(cls, /,  **kwargs) -> None:
-        super(cls).__init_subclass__(**kwargs)
+        super().__init_subclass__(**kwargs)
         cls.registry_addresses = WeakValueDictionary() # avoids sharing mutable registry with subclasses 
 
     # Object attr declarations

--- a/mupt/mutils/referencing.py
+++ b/mupt/mutils/referencing.py
@@ -12,9 +12,9 @@ class Addressable(Protocol):
     registry_addresses : ClassVar[Mapping[str, 'Addressable']]
     address : str
 
-class Addressed:
+class Addressed: # TB DEV: should name as "AddressedMixin" explicitly?
     '''
-    Boilerplate mixin for objects which are assigned a unique, hashable address at initialization
+    Mixin defining boilerplate for objects which are to be assigned a unique, hashable address at initialization
     Objects are also registered to a subclass-wide registry ("registry_addressed") keyed by their addresses
     '''
     registry_addresses : ClassVar[WeakValueDictionary[str, 'Addressed']]
@@ -28,6 +28,9 @@ class Addressed:
     _address : str
 
     def __new__(cls, *args, **kwargs) -> 'Addressed':
+        if cls is Addressed:
+            raise TypeError(f'Cannot instantiate from {cls.__name__} directly; must be used as mixin')
+
         obj = super(Addressed, cls).__new__(cls)
 
         unique_id = uuid4()

--- a/mupt/mutils/referencing.py
+++ b/mupt/mutils/referencing.py
@@ -1,9 +1,16 @@
 '''Utilities for providing Hashable references to arbitrary objects, along with registries of those objects'''
 
-from typing import ClassVar
+from typing import ClassVar, Mapping, Protocol, runtime_checkable
+
 from uuid import UUID, uuid4
 from weakref import WeakValueDictionary
 
+
+@runtime_checkable
+class Addressable(Protocol):
+    '''Behavioral interface for types which support registered, hashable object addressing'''
+    registry_addresses : ClassVar[Mapping[str, 'Addressable']]
+    address : str
 
 class Addressed:
     '''Boilerplate for objects which are assigned a universally-unique ID at initialization'''

--- a/mupt/mutils/referencing.py
+++ b/mupt/mutils/referencing.py
@@ -14,8 +14,8 @@ class Addressable(Protocol):
 
 class Addressed: # TB DEV: should name as "AddressedMixin" explicitly?
     '''
-    Mixin defining boilerplate for objects which are to be assigned a unique, hashable address at initialization
-    Objects are also registered to a subclass-wide registry ("registry_addressed") keyed by their addresses
+    Mixin defining boilerplate for objects which are to be assigned a unique, hashable address during construction.
+    Objects are also registered to a subclass-wide registry (`registry_addresses`) keyed by their addresses.
     '''
     registry_addresses : ClassVar[WeakValueDictionary[str, 'Addressed']]
     

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -1,0 +1,4 @@
+'''Unit tests for object referencing'''
+
+import pytest
+from mupt.mutils import referencing 

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -1,4 +1,23 @@
 '''Unit tests for object referencing'''
 
+from dataclasses import dataclass
+
 import pytest
-from mupt.mutils import referencing 
+from mupt.mutils.referencing import Addressable
+
+
+def test_has_address() -> None:
+    '''Test that Addressable objects indeed implement the address they claim to'''
+    ...
+
+def test_address_REgistration() -> None:
+    '''Test that newly-minted objects are also registered by their address in the classwide registry'''
+    ...
+
+def test_weak_address_refs() -> None:
+    '''Test that records of objects in classwide registry automatically vanish when object is garbage collected'''
+    ...
+
+def test_object_registries_distinct() -> None:
+    '''Test that distinct subtypes of Addressable do not share their classwide object registries'''
+    ...

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 import pytest
-from mupt.mutils.referencing import Addressed
+from mupt.mutils.referencing import Addressed, Addressable
 
 
 # dummy Addressed classes
@@ -34,6 +34,12 @@ def addressed_object_examples() -> tuple[tuple[Type[Addressed], dict[str, Any]],
     ) 
 
 # tests proper
+@pytest.mark.parametrize('addr_typ,kwargs', addressed_object_examples())
+def test_considered_addressable(addr_typ : Type[Addressed], kwargs : dict[str, Any]) -> None:
+    '''Test behavioral interface outlined by Addressable is implemented by Addressed subtypes'''
+    obj = addr_typ(**kwargs)
+    assert isinstance(obj, Addressable) # depends on having @runtime_checkable Protocol
+
 @pytest.mark.parametrize('addr_typ,kwargs', addressed_object_examples())
 def test_has_address(addr_typ : Type[Addressed], kwargs : dict[str, Any]) -> None:
     '''Test that Addressed objects indeed implement the address they claim to'''

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -5,26 +5,26 @@ from dataclasses import dataclass
 from uuid import UUID
 
 import pytest
-from mupt.mutils.referencing import Addressable
+from mupt.mutils.referencing import Addressed
 
 
-# dummy Addressable classes
-class DummyNoArgs(Addressable):
+# dummy Addressed classes
+class DummyNoArgs(Addressed):
     ...
 
-class DummyWithArgs(Addressable):
+class DummyWithArgs(Addressed):
     def __init__(self, foo : str, bar : int=123) -> None:
         self.foo = foo
         self.bar = bar
 
 @dataclass # want to ensure addr registration mechanisms plays nice w/ dataclasses
-class DummyDataclass(Addressable):
+class DummyDataclass(Addressed):
     baz : str
     boo : float
 
-def addressable_object_examples() -> tuple[tuple[Type[Addressable], dict[str, Any]], ...]:
+def addressed_object_examples() -> tuple[tuple[Type[Addressed], dict[str, Any]], ...]:
     '''
-    Pre-packaged examples of Addressable types and valid
+    Pre-packaged examples of Addressed types and valid
     arguments needed to initialize an instance of those types
     '''
     return (
@@ -34,15 +34,15 @@ def addressable_object_examples() -> tuple[tuple[Type[Addressable], dict[str, An
     ) 
 
 # tests proper
-@pytest.mark.parametrize('addr_typ,kwargs', addressable_object_examples())
-def test_has_address(addr_typ : Type[Addressable], kwargs : dict[str, Any]) -> None:
-    '''Test that Addressable objects indeed implement the address they claim to'''
+@pytest.mark.parametrize('addr_typ,kwargs', addressed_object_examples())
+def test_has_address(addr_typ : Type[Addressed], kwargs : dict[str, Any]) -> None:
+    '''Test that Addressed objects indeed implement the address they claim to'''
     obj = addr_typ(**kwargs)
     assert hasattr(obj, 'address')
     assert hasattr(obj, '_uuid') and isinstance(obj._uuid, UUID)
 
-@pytest.mark.parametrize('addr_typ,kwargs', addressable_object_examples())
-def test_address_registration(addr_typ : Type[Addressable], kwargs : dict[str, Any]) -> None:
+@pytest.mark.parametrize('addr_typ,kwargs', addressed_object_examples())
+def test_address_registration(addr_typ : Type[Addressed], kwargs : dict[str, Any]) -> None:
     '''Test that newly-minted objects are also registered by their address in the classwide registry'''
     num_obj_registered_init : int = len(addr_typ.registry_addresses)
     obj = addr_typ(**kwargs)
@@ -52,7 +52,7 @@ def test_address_registration(addr_typ : Type[Addressable], kwargs : dict[str, A
 
 def test_weak_address_refs() -> None:
     '''Test that records of objects in classwide registry automatically vanish when object is garbage collected'''
-    class DummyLocal(Addressable):
+    class DummyLocal(Addressed):
         ... # N.B.: defined locally to ensure reference counter to instances is not contaminated by other tests
 
     obj = DummyLocal()
@@ -62,11 +62,11 @@ def test_weak_address_refs() -> None:
     assert len(DummyLocal.registry_addresses) == 0
 
 def test_object_registries_distinct() -> None:
-    '''Test that distinct subtypes of Addressable do not share their classwide object registries'''
-    class DummyLocal1(Addressable):
+    '''Test that distinct subtypes of Addressed do not share their classwide object registries'''
+    class DummyLocal1(Addressed):
         ...
 
-    class DummyLocal2(Addressable):
+    class DummyLocal2(Addressed):
         ...
 
     obj1 = DummyLocal1()

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -3,6 +3,7 @@
 from typing import Any, Type
 from dataclasses import dataclass
 from uuid import UUID
+from gc import collect as garbage_collect
 
 import pytest
 from mupt.mutils.referencing import Addressed, Addressable
@@ -64,7 +65,8 @@ def test_weak_address_refs() -> None:
     obj = DummyLocal()
     assert len(DummyLocal.registry_addresses) == 1
 
-    del obj 
+    del obj
+    garbage_collect() # force garbage collector to run for deterministic tests
     assert len(DummyLocal.registry_addresses) == 0
 
 def test_object_registries_distinct() -> None:

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -35,6 +35,11 @@ def addressed_object_examples() -> tuple[tuple[Type[Addressed], dict[str, Any]],
     ) 
 
 # tests proper
+def test_addressed_base_non_instantiable() -> None:
+    '''Test that Addressed mixin base cannot be instantiated directly'''
+    with pytest.raises(TypeError):
+        obj = Addressed()
+
 @pytest.mark.parametrize('addr_typ,kwargs', addressed_object_examples())
 def test_considered_addressable(addr_typ : Type[Addressed], kwargs : dict[str, Any]) -> None:
     '''Test behavioral interface outlined by Addressable is implemented by Addressed subtypes'''

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -41,9 +41,14 @@ def test_has_address(addr_typ : Type[Addressable], kwargs : dict[str, Any]) -> N
     assert hasattr(obj, 'address')
     assert hasattr(obj, '_uuid') and isinstance(obj._uuid, UUID)
 
-def test_address_registration() -> None:
+@pytest.mark.parametrize('addr_typ,kwargs', addressable_object_examples())
+def test_address_registration(addr_typ : Type[Addressable], kwargs : dict[str, Any]) -> None:
     '''Test that newly-minted objects are also registered by their address in the classwide registry'''
-    ...
+    num_obj_registered_init : int = len(addr_typ.registry_addresses)
+    obj = addr_typ(**kwargs)
+
+    assert (obj.address in addr_typ.registry_addresses)  \
+        and (len(addr_typ.registry_addresses) == (num_obj_registered_init + 1))
 
 def test_weak_address_refs() -> None:
     '''Test that records of objects in classwide registry automatically vanish when object is garbage collected'''

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -22,19 +22,22 @@ class DummyDataclass(Addressable):
     baz : str
     boo : float
 
-
-# tests proper
-@pytest.mark.parametrize(
-    'addr_typ,args',
-    [
+def addressable_object_examples() -> tuple[tuple[Type[Addressable], dict[str, Any]], ...]:
+    '''
+    Pre-packaged examples of Addressable types and valid
+    arguments needed to initialize an instance of those types
+    '''
+    return (
         (DummyNoArgs, {}),
         (DummyWithArgs, {'foo' : 'abc', 'bar' : 42}),
         (DummyDataclass, {'baz' : 'name', 'boo' : 3.14}),
-    ]
-)
-def test_has_address(addr_typ : Type[Addressable], args : dict[str, Any]) -> None:
+    ) 
+
+# tests proper
+@pytest.mark.parametrize('addr_typ,kwargs', addressable_object_examples())
+def test_has_address(addr_typ : Type[Addressable], kwargs : dict[str, Any]) -> None:
     '''Test that Addressable objects indeed implement the address they claim to'''
-    obj = addr_typ(**args)
+    obj = addr_typ(**kwargs)
     assert hasattr(obj, 'address')
     assert hasattr(obj, '_uuid') and isinstance(obj._uuid, UUID)
 

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -1,15 +1,42 @@
 '''Unit tests for object referencing'''
 
-from typing import Type
+from typing import Any, Type
 from dataclasses import dataclass
+from uuid import UUID
 
 import pytest
 from mupt.mutils.referencing import Addressable
 
 
-def test_has_address() -> None:
-    '''Test that Addressable objects indeed implement the address they claim to'''
+# dummy Addressable classes
+class DummyNoArgs(Addressable):
     ...
+
+class DummyWithArgs(Addressable):
+    def __init__(self, foo : str, bar : int=123) -> None:
+        self.foo = foo
+        self.bar = bar
+
+@dataclass # want to ensure addr registration mechanisms plays nice w/ dataclasses
+class DummyDataclass(Addressable):
+    baz : str
+    boo : float
+
+
+# tests proper
+@pytest.mark.parametrize(
+    'addr_typ,args',
+    [
+        (DummyNoArgs, {}),
+        (DummyWithArgs, {'foo' : 'abc', 'bar' : 42}),
+        (DummyDataclass, {'baz' : 'name', 'boo' : 3.14}),
+    ]
+)
+def test_has_address(addr_typ : Type[Addressable], args : dict[str, Any]) -> None:
+    '''Test that Addressable objects indeed implement the address they claim to'''
+    obj = addr_typ(**args)
+    assert hasattr(obj, 'address')
+    assert hasattr(obj, '_uuid') and isinstance(obj._uuid, UUID)
 
 def test_address_registration() -> None:
     '''Test that newly-minted objects are also registered by their address in the classwide registry'''
@@ -17,14 +44,14 @@ def test_address_registration() -> None:
 
 def test_weak_address_refs() -> None:
     '''Test that records of objects in classwide registry automatically vanish when object is garbage collected'''
-    class Dummy(Addressable):
-        ... # N.B.: defined locally to ensure reference counter to instances are not contaminated by other tests
+    class DummyLocal(Addressable):
+        ... # N.B.: defined locally to ensure reference counter to instances is not contaminated by other tests
 
-    obj = Dummy()
-    assert len(Dummy.registry_addresses) == 1
+    obj = DummyLocal()
+    assert len(DummyLocal.registry_addresses) == 1
 
     del obj 
-    assert len(Dummy.registry_addresses) == 0
+    assert len(DummyLocal.registry_addresses) == 0
 
 def test_object_registries_distinct() -> None:
     '''Test that distinct subtypes of Addressable do not share their classwide object registries'''

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -1,5 +1,6 @@
 '''Unit tests for object referencing'''
 
+from typing import Type
 from dataclasses import dataclass
 
 import pytest
@@ -10,13 +11,20 @@ def test_has_address() -> None:
     '''Test that Addressable objects indeed implement the address they claim to'''
     ...
 
-def test_address_REgistration() -> None:
+def test_address_registration() -> None:
     '''Test that newly-minted objects are also registered by their address in the classwide registry'''
     ...
 
 def test_weak_address_refs() -> None:
     '''Test that records of objects in classwide registry automatically vanish when object is garbage collected'''
-    ...
+    class Dummy(Addressable):
+        ... # N.B.: defined locally to ensure reference counter to instances are not contaminated by other tests
+
+    obj = Dummy()
+    assert len(Dummy.registry_addresses) == 1
+
+    del obj 
+    assert len(Dummy.registry_addresses) == 0
 
 def test_object_registries_distinct() -> None:
     '''Test that distinct subtypes of Addressable do not share their classwide object registries'''

--- a/mupt/tests/mutils/test_referencing.py
+++ b/mupt/tests/mutils/test_referencing.py
@@ -63,4 +63,14 @@ def test_weak_address_refs() -> None:
 
 def test_object_registries_distinct() -> None:
     '''Test that distinct subtypes of Addressable do not share their classwide object registries'''
-    ...
+    class DummyLocal1(Addressable):
+        ...
+
+    class DummyLocal2(Addressable):
+        ...
+
+    obj1 = DummyLocal1()
+    assert (obj1.address not in DummyLocal2.registry_addresses)
+
+    obj2 = DummyLocal2() # perform reciprocal test to check symmetry
+    assert (obj2.address not in DummyLocal1.registry_addresses)


### PR DESCRIPTION
## Description
Many of the changes to the components of the MuPT representation being developed in #56 and #82 would benefit from having unique, hashable "addresses" associated with objects like Primitive and Connector, for reasons including:
* Disambiguating references to the same object from different resolution scales (which handles do the opposite of)
* Eschewing linear search when modifying horizontal or vertical connections in favor of constant-time address lookup
* Representing Primitives as [node in `networkx` digraphs with a hashable identifier](https://networkx.org/documentation/stable/tutorial.html#:~:text=In%20NetworkX%2C%20nodes%20can%20be%20any%20hashable%20object%20e.g.%2C%20a%20text%20string%2C%20an%20image%2C%20an%20XML%20object%2C%20another%20Graph%2C%20a%20customized%20node%20object%2C%20etc.) (which is instance-specific, unlike `__hash__`, and session-persistent, unlike `id()`)

This PR is intended to introduce generic logic for this kind of addressing via a Mixin which can be reused without duplicating code between classes in the mentioned PRs.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] An Addressed base class which:
    - [x] Assigns new instances a unique address at init time
    - [x] Registers the instances and their address to a class-specific registry which does not interfere with the garbage collector
  - [x] An Addressable Protocol to enable behavioral typechecking and inclusion of other Addressed-like classes in downstream code that depends on addressing

## Questions
- [ ] Should an analogous base class be written for label/handle assignment and registering? _DEV: seems like a bad idea, since not thread safe, relies on a running counter, partially duplicates UniqueRegistry, and requires impl as a metaclass in order to inject label into `__init__` args of child classes_
- [ ] Will [UniqueRegistry](https://github.com/MuPT-hub/mupt/blob/main/mupt/mutils/containers.py#L31) be necessary in the mid-term if pivoting to UUID-like object reference instead?

## Status
- [x] Tests
  - [x] Write accompanying tests
  - [x] Ensure tests pass on CI run
- [x] Review 
  - [x] Address Copilot suggestions
  - [ ] Pass human review