### PR TITLE
Pin openff-nagl-models to restore NB test passes in CI

### DIFF
--- a/devtools/conda-envs/dev-env.yml
+++ b/devtools/conda-envs/dev-env.yml
@@ -28,36 +28,27 @@ dependencies:
   - matplotlib
   - ipympl
 
-  # Molecular libraries
-  - rdkit
-  - py3Dmol
-  - openbabel>=3.0
-  - mbuild >=1.0
-  - periodictable
-
-  # MD libraries
-  - openff-toolkit
-  - openff-interchange
-  - hoomd=5.3.0
-  - freud=3.0
-  # - fresnel
   # Chemistry
   - rdkit
   - periodictable
 
   # Molecular Dynamics toolkits
+  ## Visualization
+  - py3Dmol
+  - openbabel>=3.0
+
   ## OpenFF
   - openff-toolkit>=0.18
   - openff-interchange>=0.5
 
   ## HOOMD
-  - hoomd
+  - hoomd>=5.3.0
   - gsd>=3.0
-  - freud
+  - freud>=3.0
   - fresnel
 
   ## MoSDeF
-  # - mbuild # DEV: dependencies and env solve really don't play nice w/ OpenFF - hiding for now, since unused in code + examples
+  # - mbuild>=1.0 # DEV: dependencies and env solve really don't play nice w/ OpenFF - hiding for now, since unused in code + examples
   - gmso
 
   ## Analysis

--- a/devtools/conda-envs/dev-env.yml
+++ b/devtools/conda-envs/dev-env.yml
@@ -40,6 +40,7 @@ dependencies:
   ## OpenFF
   - openff-toolkit>=0.18
   - openff-interchange>=0.5
+  - openff-nagl-models
 
   ## HOOMD
   - hoomd>=5.3.0

--- a/devtools/conda-envs/release-env.yml
+++ b/devtools/conda-envs/release-env.yml
@@ -37,6 +37,7 @@ dependencies:
   ## OpenFF
   - openff-toolkit>=0.18
   - openff-interchange>=0.5
+  - openff-nagl-models
 
   ## HOOMD
   - hoomd


### PR DESCRIPTION
## Description
Recent updates to `openff-nagl`, namely v0.5.5 -> v0.6.0, have caused [mupt-examples](https://github.com/MuPT-hub/mupt-examples) notebook [tests to fail](https://github.com/MuPT-hub/mupt/actions/runs/34294985867). Specifically, this is caused by `openff-nagl-models` no longer being installed by default w/ nagl v0.6.0, resulting in the [mdfiles_with_openff.ipynb](https://github.com/MuPT-hub/mupt-examples/blob/main/examples_system/mdfiles_with_openff.ipynb) raising Exception when attempting to assign partial charges with the `openff-gnn-am1bcc-1.0.0.pt` method.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Pin openff-nagl-models install in release-env.yml (ensuring compatibility regardless of nagl version)
  - [x] Clean up duplication in env files in `devtools/conda_envs/*`

## Status
- [x] Verify CI tests pass
- [ ] Merge into main
  - [ ] Rerun CI on parallel branches to ensure this fix propagates